### PR TITLE
chore: combine all Dependabot dependency updates

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR description for issue link
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check version match
         run: |
@@ -47,7 +47,7 @@ jobs:
           - aarch64-unknown-linux-gnu
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -72,7 +72,7 @@ jobs:
           tar -czf ../../../taws-${{ matrix.target }}.tar.gz taws
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: taws-${{ matrix.target }}
           path: taws-${{ matrix.target }}.tar.gz
@@ -87,7 +87,7 @@ jobs:
           - aarch64-apple-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -105,7 +105,7 @@ jobs:
           tar -czf ../../../taws-${{ matrix.target }}.tar.gz taws
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: taws-${{ matrix.target }}
           path: taws-${{ matrix.target }}.tar.gz
@@ -115,7 +115,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -133,7 +133,7 @@ jobs:
           7z a ../../../taws-x86_64-pc-windows-msvc.zip taws.exe
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: taws-x86_64-pc-windows-msvc
           path: taws-x86_64-pc-windows-msvc.zip
@@ -143,10 +143,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: taws-*
           merge-multiple: true
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: taws-*
           merge-multiple: true
@@ -200,7 +200,7 @@ jobs:
           echo "linux_arm64=$(sha256sum taws-aarch64-unknown-linux-gnu.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: huseyinbabal/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -264,7 +264,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Windows artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: taws-x86_64-pc-windows-msvc
           path: .
@@ -279,7 +279,7 @@ jobs:
           echo "windows_amd64=$(sha256sum taws-x86_64-pc-windows-msvc.zip | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
       - name: Checkout scoop-bucket
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: huseyinbabal/scoop-bucket
           token: ${{ secrets.SCOOP_BUCKET_TOKEN }}

--- a/.github/workflows/stale-branch.yml
+++ b/.github/workflows/stale-branch.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete merged branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             if (context.eventName === 'pull_request') {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
@@ -2304,7 +2304,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 
 # XML parsing (for EC2, IAM, RDS Query protocol APIs)
-quick-xml = { version = "0.37", features = ["serialize"] }
+quick-xml = { version = "0.38", features = ["serialize"] }
 
 # CLI argument parsing
 clap = { version = "4.5", features = ["derive"] }
@@ -47,7 +47,7 @@ tracing-appender = "0.2"
 
 # Utils
 anyhow = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 dirs = "6.0"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 sha1 = "0.10"


### PR DESCRIPTION
## Summary
- Bump quick-xml from 0.37.5 to 0.38.4
- Bump thiserror from 1.0.69 to 2.0.17
- Bump actions/checkout from v4 to v6
- Bump actions/upload-artifact from v4 to v6
- Bump actions/download-artifact from v4 to v7
- Bump actions/github-script from v7 to v8

Also fixes breaking change in quick-xml 0.38 API (`unescape()` -> `xml_content()`)

Closes #58
Closes #59
Closes #60
Closes #61
Closes #62
Closes #63