### PR TITLE
Add confirmation dialogs for start and rotate actions

### DIFF
--- a/src/resources/ec2.json
+++ b/src/resources/ec2.json
@@ -20,7 +20,7 @@
       ],
       "sub_resources": [],
       "actions": [
-        { "key": "s", "display_name": "Start", "shortcut": "s", "sdk_method": "start_instance" },
+        { "key": "s", "display_name": "Start", "shortcut": "s", "sdk_method": "start_instance", "confirm": { "message": "Start instance", "default_yes": false } },
         { "key": "S", "display_name": "Stop", "shortcut": "S", "sdk_method": "stop_instance", "confirm": { "message": "Stop instance", "default_yes": false } },
         { "key": "r", "display_name": "Reboot", "shortcut": "r", "sdk_method": "reboot_instance", "confirm": { "message": "Reboot instance", "default_yes": false } },
         { "key": "ctrl+d", "display_name": "Terminate", "shortcut": "ctrl+d", "sdk_method": "terminate_instance", "confirm": { "message": "Terminate instance", "default_yes": false, "destructive": true } }

--- a/src/resources/rds.json
+++ b/src/resources/rds.json
@@ -20,7 +20,7 @@
         { "shortcut": "n", "display_name": "Snapshots", "resource_key": "rds-snapshots", "parent_id_field": "DBInstanceIdentifier", "filter_param": "db_instance_identifier" }
       ],
       "actions": [
-        { "key": "s", "display_name": "Start", "shortcut": "s", "sdk_method": "start_db_instance" },
+        { "key": "s", "display_name": "Start", "shortcut": "s", "sdk_method": "start_db_instance", "confirm": { "message": "Start RDS instance", "default_yes": false } },
         { "key": "S", "display_name": "Stop", "shortcut": "S", "sdk_method": "stop_db_instance", "confirm": { "message": "Stop RDS instance", "default_yes": false } },
         { "key": "r", "display_name": "Reboot", "shortcut": "r", "sdk_method": "reboot_db_instance", "confirm": { "message": "Reboot RDS instance", "default_yes": false } },
         { "key": "ctrl+d", "display_name": "Delete", "shortcut": "ctrl+d", "sdk_method": "delete_db_instance", "confirm": { "message": "Delete RDS instance", "default_yes": false, "destructive": true } }

--- a/src/resources/secretsmanager.json
+++ b/src/resources/secretsmanager.json
@@ -17,7 +17,7 @@
       ],
       "sub_resources": [],
       "actions": [
-        { "key": "R", "display_name": "Rotate Secret", "shortcut": "R", "sdk_method": "rotate_secret" },
+        { "key": "R", "display_name": "Rotate Secret", "shortcut": "R", "sdk_method": "rotate_secret", "confirm": { "message": "Rotate secret", "default_yes": false } },
         { "key": "ctrl+d", "display_name": "Delete Secret", "shortcut": "ctrl+d", "sdk_method": "delete_secret", "confirm": { "message": "Delete secret", "default_yes": false, "destructive": true } }
       ]
     }


### PR DESCRIPTION
## Summary

- Add confirmation modal to EC2 start instance action (`s` key)
- Add confirmation modal to RDS start instance action (`s` key)  
- Add confirmation modal to Secrets Manager rotate secret action (`R` key)

## Related Issue

Closes #74

## Rationale

The user raised a valid concern: pressing `s` (start) accidentally instead of `d` (details) could start instances and incur unexpected AWS charges. Other state-changing actions like stop (`S`) and reboot (`r`) already require confirmation.

This PR adds confirmation dialogs to all remaining write/modify operations that were missing them:

| Service | Action | Key | Before | After |
|---------|--------|-----|--------|-------|
| EC2 | Start Instance | `s` | No confirmation | ✅ Confirmation |
| RDS | Start Instance | `s` | No confirmation | ✅ Confirmation |
| Secrets Manager | Rotate Secret | `R` | No confirmation | ✅ Confirmation |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked this PR to an existing issue
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] My changes don't introduce new warnings