### PR TITLE
Fix workflow permissions for security scan

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
 jobs:
   check:
     uses: huseyinbabal/rust-actions/.github/workflows/pr-check.yml@main


### PR DESCRIPTION
## Summary

Fix the GitHub Actions workflow error:

```
The nested job 'security-scan' is requesting 'actions: read, security-events: write', 
but is only allowed 'actions: none, security-events: none'.
```

## Solution

Add required permissions at the workflow level:

```yaml
permissions:
  contents: read
  actions: read
  security-events: write
```

This allows the reusable workflow's `security-scan` job to:
- Read actions metadata (`actions: read`)
- Write security scan results to the Security tab (`security-events: write`)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)