### PR TITLE
fix: Support AWS_SHARED_CREDENTIALS_FILE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ See [Authentication](#authentication) for credential setup.
 | `AWS_ACCESS_KEY_ID` | AWS access key |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key |
 | `AWS_SESSION_TOKEN` | AWS session token (for temporary credentials) |
+| `AWS_SHARED_CREDENTIALS_FILE` | Custom path to credentials file (default: `~/.aws/credentials`) |
+| `AWS_CONFIG_FILE` | Custom path to config file (default: `~/.aws/config`) |
 | `AWS_ENDPOINT_URL` | Custom endpoint URL (for LocalStack, etc.) |
 
 ---

--- a/src/aws/credentials.rs
+++ b/src/aws/credentials.rs
@@ -227,9 +227,14 @@ fn parse_ini_file(content: &str) -> HashMap<String, HashMap<String, String>> {
     sections
 }
 
-/// Load credentials from ~/.aws/credentials
+/// Load credentials from ~/.aws/credentials or AWS_SHARED_CREDENTIALS_FILE
 fn load_from_credentials_file(profile: &str) -> Result<Credentials> {
-    let creds_path = aws_config_dir()?.join("credentials");
+    // Check AWS_SHARED_CREDENTIALS_FILE env var first (AWS SDK standard)
+    let creds_path = if let Ok(path) = env::var("AWS_SHARED_CREDENTIALS_FILE") {
+        PathBuf::from(path)
+    } else {
+        aws_config_dir()?.join("credentials")
+    };
     let content =
         fs::read_to_string(&creds_path).map_err(|_| anyhow!("Could not read {:?}", creds_path))?;
 


### PR DESCRIPTION
## Summary

Fixes #70

The `AWS_SHARED_CREDENTIALS_FILE` environment variable was not being respected when loading credentials, even though it was already implemented for profile listing in `profiles.rs`.

## Problem

When users set `AWS_SHARED_CREDENTIALS_FILE` to a custom credentials file path, taws would still look for credentials in the default `~/.aws/credentials` location, causing authentication to fail.

## Solution

Check `AWS_SHARED_CREDENTIALS_FILE` env var in `load_from_credentials_file()` before falling back to the default path, matching AWS SDK standard behavior.

## Testing

```bash
# Set custom credentials file
export AWS_SHARED_CREDENTIALS_FILE=/path/to/custom/credentials
export AWS_PROFILE=myprofile

# This should now work
taws --readonly
```