### PR TITLE
feat: Add SSM Connect for EC2 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ AWS_ENDPOINT_URL=http://localhost:4566 taws
 | Region shortcuts | `0-5` | Quick switch to common regions |
 | Quit | `Ctrl-c` | Exit taws |
 | **EC2 Actions** | | |
+| Connect (SSM) | `c` | Open SSM shell session to instance |
 | Start instance | `s` | Start selected EC2 instance |
 | Stop instance | `S` | Stop selected EC2 instance |
 | Terminate | `Ctrl+d` | Terminate selected EC2 instance |
@@ -327,6 +328,20 @@ See [Authentication](#authentication) for credential setup.
 | `AWS_SHARED_CREDENTIALS_FILE` | Custom path to credentials file (default: `~/.aws/credentials`) |
 | `AWS_CONFIG_FILE` | Custom path to config file (default: `~/.aws/config`) |
 | `AWS_ENDPOINT_URL` | Custom endpoint URL (for LocalStack, etc.) |
+
+---
+
+## SSM Connect (EC2 Shell Access)
+
+Press `c` on a running EC2 instance to open an interactive shell session via AWS Systems Manager.
+
+**Requirements:**
+- [session-manager-plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) must be installed
+- EC2 instance must have SSM Agent running
+- Instance must be running (not stopped/terminated)
+- Linux instances only (Windows not supported via shell)
+
+**Note:** When you exit the shell session (`exit`), you'll return to taws.
 
 ---
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -234,6 +234,10 @@ async fn handle_normal_mode(app: &mut App, key: KeyEvent) -> Result<bool> {
                                         if action.sdk_method == "tail_logs" {
                                             app.enter_log_tail_mode().await?;
                                             handled = true;
+                                        // Special handling for SSM connect
+                                        } else if action.sdk_method == "ssm_connect" {
+                                            app.request_ssm_connect();
+                                            handled = true;
                                         // Block action in readonly mode
                                         } else if app.readonly {
                                             app.show_warning(

--- a/src/resources/ec2.json
+++ b/src/resources/ec2.json
@@ -20,6 +20,7 @@
       ],
       "sub_resources": [],
       "actions": [
+        { "key": "c", "display_name": "Connect (SSM)", "shortcut": "c", "sdk_method": "ssm_connect" },
         { "key": "s", "display_name": "Start", "shortcut": "s", "sdk_method": "start_instance", "confirm": { "message": "Start instance", "default_yes": false } },
         { "key": "S", "display_name": "Stop", "shortcut": "S", "sdk_method": "stop_instance", "confirm": { "message": "Stop instance", "default_yes": false } },
         { "key": "r", "display_name": "Reboot", "shortcut": "r", "sdk_method": "reboot_instance", "confirm": { "message": "Reboot instance", "default_yes": false } },
@@ -38,6 +39,7 @@
         "PublicIpAddress": { "source": "/ipAddress", "default": "-" },
         "PrivateIpAddress": { "source": "/privateIpAddress", "default": "-" },
         "LaunchTime": { "source": "/launchTime", "default": "-" },
+        "Platform": { "source": "/platform", "default": "" },
         "Tags": { "source": "/tagSet/item", "transform": "tags_to_map" }
       },
       "action_configs": {

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -31,6 +31,7 @@ pub fn render(f: &mut Frame, _app: &App) {
         create_key_line("?", "Toggle help"),
         Line::from(""),
         create_section("EC2 Actions"),
+        create_key_line("c", "Connect via SSM"),
         create_key_line("s", "Start instance"),
         create_key_line("S", "Stop instance"),
         create_key_line("r", "Reboot instance"),


### PR DESCRIPTION
## Summary

Fixes #69

Adds one-key SSM shell access to EC2 instances, similar to k9s pod shell feature.

## Usage

1. Navigate to EC2 instances view
2. Select a running Linux instance
3. Press `c` to connect
4. Use the shell session
5. Type `exit` to return to taws

## Features

- **Validation**: Checks instance is running before connecting
- **Windows blocking**: Shows warning for Windows instances (shell not supported, use RDP)
- **Plugin check**: Verifies `session-manager-plugin` is installed
- **Clean TUI handling**: Suspends TUI, runs SSM session, restores TUI on exit

## Requirements

- [session-manager-plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed
- EC2 instance with SSM Agent running
- IAM permissions for `ssm:StartSession`

## Demo

```
# In taws EC2 view, press 'c' on a running instance:

>>> Connecting to i-0123456789abcdef via SSM...

sh-4.2$ whoami
ec2-user
sh-4.2$ exit

>>> Returning to taws... Press any key.
```