### PR TITLE
feat: Support credential_source for ECS/EC2/Environment credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ See [Authentication](#authentication) for credential setup.
 | `AWS_SESSION_TOKEN` | AWS session token (for temporary credentials) |
 | `AWS_SHARED_CREDENTIALS_FILE` | Custom path to credentials file (default: `~/.aws/credentials`) |
 | `AWS_CONFIG_FILE` | Custom path to config file (default: `~/.aws/config`) |
-| `AWS_ENDPOINT_URL` | Custom endpoint URL (for LocalStack, etc.) |
+| `AWS_ENDPOINT_URL` | Custom endpoint URL (for LocalStack, etc.) - also used for STS AssumeRole |
 
 ---
 


### PR DESCRIPTION
## Summary

Add support for `credential_source` configuration which allows loading credentials from ECS container credentials, EC2 instance metadata, or environment variables when assuming a role.

Closes #15

## Changes

- **Parse credential_source** from config file (Environment, Ec2InstanceMetadata, EcsContainer)
- **Add CredentialSource enum** for type-safe credential source handling
- **Implement load_from_ecs_container()** for ECS task credentials
- **Modify load_from_assume_role()** to handle both `source_profile` and `credential_source`
- **Validate configuration** - exactly one of `source_profile` OR `credential_source` must be set
- **Add ECS_CACHE** for caching ECS container credentials with expiration

## Supported credential_source values

| Value | Description |
|-------|-------------|
| `Environment` | Load from `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` |
| `Ec2InstanceMetadata` | Load from EC2 instance metadata (IMDSv2) |
| `EcsContainer` | Load from ECS container credentials endpoint |

## Example Configuration

```ini
# For ECS tasks with task IAM roles
[profile ecs-admin]
role_arn = arn:aws:iam::123456789012:role/AdminRole
credential_source = EcsContainer

# For EC2 instances with instance roles  
[profile ec2-admin]
role_arn = arn:aws:iam::123456789012:role/AdminRole
credential_source = Ec2InstanceMetadata

# For environments with env vars set
[profile env-admin]
role_arn = arn:aws:iam::123456789012:role/AdminRole
credential_source = Environment
```

## Use Cases

- Running taws in ECS tasks with task IAM roles
- Running taws in Lambda functions
- Using EC2 instance roles as base for role assumption
- Container-based deployments with IAM roles

## Testing

- Added unit tests for `parse_credential_source()`, ECS cache, and INI parsing
- All 67 tests pass
- Clippy passes with no warnings