### PR TITLE
fix: Support AWS CLI v2 SSO cache and CLI assume-role cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,6 +2322,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha1",
+ "tempfile",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2323,6 +2330,19 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "urlencoding",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,4 @@ async-trait = "0.1.89"
 
 [dev-dependencies]
 dirs = "6.0"
+tempfile = "3.24.0"

--- a/src/aws/sso.rs
+++ b/src/aws/sso.rs
@@ -57,13 +57,17 @@ struct TokenResponse {
     expires_in: i64,
 }
 
-/// Cached SSO token format (compatible with AWS CLI)
+/// Cached SSO token format (compatible with AWS CLI v1 and v2)
+/// Supports both snake_case (v1/legacy) and camelCase (v2) field names via aliases
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 struct CachedToken {
+    #[serde(alias = "accessToken")]
     access_token: String,
+    #[serde(alias = "expiresAt")]
     expires_at: String,
-    region: String,
+    #[serde(default, alias = "region")]
+    region: Option<String>,
+    #[serde(alias = "startUrl")]
     start_url: String,
 }
 
@@ -294,7 +298,7 @@ fn cache_sso_token(config: &SsoConfig, access_token: &str, expires_in: i64) -> R
     let cached_token = CachedToken {
         access_token: access_token.to_string(),
         expires_at: expires_at_str,
-        region: config.sso_region.clone(),
+        region: Some(config.sso_region.clone()),
         start_url: config.sso_start_url.clone(),
     };
 
@@ -481,23 +485,54 @@ fn parse_ini_sections(
 }
 
 /// Read cached SSO token if valid
+/// Tries multiple cache file formats for compatibility with AWS CLI v1 and v2
 pub fn read_cached_token(config: &SsoConfig) -> Option<String> {
     let cache_dir = aws_config_dir().ok()?.join("sso").join("cache");
 
-    // Cache file name is SHA1 of start_url (compatible with AWS CLI for both legacy and new format)
+    // AWS CLI v2 with sso_session uses SHA1 of the session name for cache file
+    // Try this format first as it's the most current
+    let mut hasher = Sha1::new();
+    hasher.update(config.sso_session.as_bytes());
+    let hash = hasher.finalize();
+    let cache_file_v2 = format!("{:x}.json", hash);
+    let cache_path_v2 = cache_dir.join(&cache_file_v2);
+
+    if let Some(token) = try_read_token_file(&cache_path_v2) {
+        debug!(
+            "Found valid SSO token using CLI v2 format (sso_session: {})",
+            config.sso_session
+        );
+        return Some(token);
+    }
+
+    // AWS CLI v1 / legacy format uses SHA1 of start_url for cache file
     let mut hasher = Sha1::new();
     hasher.update(config.sso_start_url.as_bytes());
     let hash = hasher.finalize();
-    let cache_file_name = format!("{:x}.json", hash);
-    let cache_path = cache_dir.join(&cache_file_name);
+    let cache_file_legacy = format!("{:x}.json", hash);
+    let cache_path_legacy = cache_dir.join(&cache_file_legacy);
 
-    let content = fs::read_to_string(&cache_path).ok()?;
+    if let Some(token) = try_read_token_file(&cache_path_legacy) {
+        debug!("Found valid SSO token using legacy format (start_url-based)");
+        return Some(token);
+    }
+
+    trace!(
+        "No valid SSO token found in cache for session '{}' or start_url",
+        config.sso_session
+    );
+    None
+}
+
+/// Helper function to read and validate a token file
+fn try_read_token_file(cache_path: &std::path::Path) -> Option<String> {
+    let content = fs::read_to_string(cache_path).ok()?;
     let cached: CachedToken = serde_json::from_str(&content).ok()?;
 
     // Check expiration
     if let Ok(expires_at) = chrono::DateTime::parse_from_rfc3339(&cached.expires_at) {
         if expires_at <= chrono::Utc::now() {
-            debug!("SSO token expired");
+            trace!("SSO token in {:?} is expired", cache_path);
             return None;
         }
     }


### PR DESCRIPTION
## Summary

Fix issue where taws doesn't recognize active sessions created by other tools (AWS CLI v2, external apps).

Closes #85

## Changes

### 1. SSO Token Cache (`sso.rs`)
- Support CLI v2 format: `SHA1(sso_session)` for cache file name
- Support CLI v1/legacy format: `SHA1(sso_start_url)` as fallback
- Support both `snake_case` and `camelCase` field names via serde aliases
- Make `region` field optional (not all cache files have it)

### 2. AWS CLI Assume-Role Cache (`credentials.rs`)
- Read cached credentials from `~/.aws/cli/cache/`
- Match cache files by comparing role ARN and account ID
- Check expiration before using cached credentials
- Fall back to performing STS AssumeRole if no valid cache found

### 3. Tests
- Add tests for CLI cache file matching logic
- Add tests for expired credential handling
- Add tests for non-matching role ARNs

## What This Enables

taws can now use credentials cached by:
- `aws sso login` (CLI v2)
- `aws sts get-caller-identity --profile <assume-role-profile>`
- External tools that populate `~/.aws/cli/cache/`

## Priority Order for Role Assumption Profiles

When a profile has `role_arn` configured:
1. First check `~/.aws/cli/cache/` for existing valid credentials
2. If not found, perform STS AssumeRole (existing behavior)

This avoids unnecessary API calls when valid credentials already exist.