### PR TITLE
Add search functionality for resource description view

### DIFF
--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -36,6 +36,8 @@ pub fn render(f: &mut Frame, _app: &App) {
         create_key_line("PgDn / Ctrl+f", "Page down"),
         create_key_line("g / Home", "Go to top"),
         create_key_line("G / End", "Go to bottom"),
+        create_key_line("/", "Search in content"),
+        create_key_line("n / N", "Next/prev match"),
         create_key_line("q / Esc / d", "Close details"),
         Line::from(""),
         create_section("EC2 Actions"),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -294,10 +294,6 @@ fn render_describe_view(f: &mut Frame, app: &App, area: Rect) {
         .selected_item_json()
         .unwrap_or_else(|| "No item selected".to_string());
 
-    // Apply JSON syntax highlighting
-    let lines: Vec<Line> = json.lines().map(highlight_json_line).collect();
-    let total_lines = lines.len();
-
     let title = if let Some(resource) = app.current_resource() {
         describe_title(
             &resource.display_name,
@@ -320,14 +316,143 @@ fn render_describe_view(f: &mut Frame, app: &App, area: Rect) {
     let inner_area = block.inner(area);
     f.render_widget(block, area);
 
-    // Calculate max scroll based on inner area (content area without borders)
-    let visible_lines = inner_area.height as usize;
+    // Split inner area for search bar if search is active or has text
+    let show_search = app.describe_search_active || !app.describe_search_text.is_empty();
+    let (content_area, search_area) = if show_search {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(inner_area);
+        (chunks[0], Some(chunks[1]))
+    } else {
+        (inner_area, None)
+    };
+
+    // Apply JSON syntax highlighting with search match highlighting
+    let search_text = &app.describe_search_text;
+    let lines: Vec<Line> = json
+        .lines()
+        .enumerate()
+        .map(|(line_num, line)| {
+            let is_current_match = app
+                .describe_match_lines
+                .get(app.describe_current_match)
+                .map(|&m| m == line_num)
+                .unwrap_or(false);
+            highlight_json_line_with_search(line, search_text, is_current_match)
+        })
+        .collect();
+    let total_lines = lines.len();
+
+    // Calculate max scroll based on content area
+    let visible_lines = content_area.height as usize;
     let max_scroll = total_lines.saturating_sub(visible_lines);
     let scroll = app.describe_scroll.min(max_scroll);
 
     let paragraph = Paragraph::new(lines.clone()).scroll((scroll as u16, 0));
+    f.render_widget(paragraph, content_area);
 
-    f.render_widget(paragraph, inner_area);
+    // Render search bar if active
+    if let Some(search_area) = search_area {
+        render_describe_search_bar(f, app, search_area);
+    }
+}
+
+fn render_describe_search_bar(f: &mut Frame, app: &App, area: Rect) {
+    let match_info = if app.describe_match_lines.is_empty() {
+        if app.describe_search_text.is_empty() {
+            String::new()
+        } else {
+            " [no matches]".to_string()
+        }
+    } else {
+        format!(
+            " [{}/{}]",
+            app.describe_current_match + 1,
+            app.describe_match_lines.len()
+        )
+    };
+
+    let cursor = if app.describe_search_active { "_" } else { "" };
+    let search_display = format!("/{}{}{}", app.describe_search_text, cursor, match_info);
+
+    let style = if app.describe_search_active {
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    let paragraph = Paragraph::new(Line::from(vec![Span::styled(search_display, style)]));
+    f.render_widget(paragraph, area);
+}
+
+/// Apply JSON syntax highlighting with search term highlighting
+fn highlight_json_line_with_search(
+    line: &str,
+    search_text: &str,
+    is_current_match: bool,
+) -> Line<'static> {
+    if search_text.is_empty() {
+        return highlight_json_line(line);
+    }
+
+    let line_lower = line.to_lowercase();
+    let search_lower = search_text.to_lowercase();
+
+    // If no match in this line, just use regular highlighting
+    if !line_lower.contains(&search_lower) {
+        return highlight_json_line(line);
+    }
+
+    // Build line with search highlights
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut last_end = 0;
+
+    // Find all occurrences (case-insensitive)
+    let mut search_start = 0;
+    while let Some(pos) = line_lower[search_start..].find(&search_lower) {
+        let match_start = search_start + pos;
+        let match_end = match_start + search_text.len();
+
+        // Add text before match with JSON highlighting (simplified - just use default color)
+        if match_start > last_end {
+            let before = &line[last_end..match_start];
+            // Apply simple JSON coloring to the before part
+            for span in highlight_json_line(before).spans {
+                spans.push(span);
+            }
+        }
+
+        // Add matched text with highlight
+        let matched = &line[match_start..match_end];
+        let highlight_style = if is_current_match {
+            Style::default()
+                .bg(Color::Yellow)
+                .fg(Color::Black)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+                .bg(Color::DarkGray)
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD)
+        };
+        spans.push(Span::styled(matched.to_string(), highlight_style));
+
+        last_end = match_end;
+        search_start = match_end;
+    }
+
+    // Add remaining text after last match
+    if last_end < line.len() {
+        let after = &line[last_end..];
+        for span in highlight_json_line(after).spans {
+            spans.push(span);
+        }
+    }
+
+    Line::from(spans)
 }
 
 fn render_log_tail_view(f: &mut Frame, app: &App, area: Rect) {
@@ -578,7 +703,13 @@ fn render_crumb(f: &mut Frame, app: &App, area: Rect) {
     } else if app.loading {
         "Loading...".to_string()
     } else if app.mode == Mode::Describe {
-        "j/k: scroll | q/d/Esc: back".to_string()
+        if app.describe_search_active {
+            "Type to search | Enter: confirm | Esc: cancel".to_string()
+        } else if !app.describe_search_text.is_empty() {
+            "n/N: next/prev match | /: new search | Esc: clear".to_string()
+        } else {
+            "j/k: scroll | /: search | q/d/Esc: back".to_string()
+        }
     } else if app.mode == Mode::LogTail {
         "j/k: scroll | G: bottom (live) | g: top | SPACE: pause | q: exit".to_string()
     } else if app.filter_active {


### PR DESCRIPTION
## Summary
- Add search within resource description/JSON details view using `/` key
- Highlight all matches with different colors for current vs other matches
- Navigate between matches with `n`/`N` keys

## Features
- **Search activation**: Press `/` in describe mode to start searching
- **Real-time highlighting**: All matches highlighted as you type
- **Match navigation**: Use `n` for next match, `N` for previous match
- **Match counter**: Shows current position (e.g., `[2/5]`)
- **Auto-scroll**: Automatically scrolls to first match when searching

## Key Bindings (Describe Mode)
| Key | Action |
|-----|--------|
| `/` | Start search |
| `n` | Jump to next match |
| `N` | Jump to previous match |
| `Enter` | Confirm search (exit input mode) |
| `Esc` | Clear search / exit describe mode |

## Screenshots
The search bar appears at the bottom of the describe view when active:
```
/tagSet [2/5]
```

Matches are highlighted:
- **Current match**: Yellow background with black text
- **Other matches**: Gray background with white text

Closes #94