### PR TITLE
Add shell completion support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,6 +2311,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "chrono",
  "clap",
+ "clap_complete",
  "crossterm",
  "dirs",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ quick-xml = { version = "0.38", features = ["serialize"] }
 
 # CLI argument parsing
 clap = { version = "4.5", features = ["derive"] }
+clap_complete = "4.5"
 
 # Logging
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -294,6 +294,26 @@ AWS_ENDPOINT_URL=http://localhost:4566 taws
 | **macOS** | `~/Library/Application Support/taws/taws.log` |
 | **Windows** | `%APPDATA%\taws\taws.log` |
 
+### Shell Completion
+
+taws supports shell completion for bash, zsh, fish, and PowerShell.
+
+```bash
+# Bash (add to ~/.bashrc)
+eval "$(taws completion bash)"
+
+# Zsh (add to ~/.zshrc)
+eval "$(taws completion zsh)"
+
+# Fish (add to ~/.config/fish/config.fish)
+taws completion fish | source
+
+# PowerShell (add to $PROFILE)
+taws completion powershell | Out-String | Invoke-Expression
+```
+
+After adding the completion script, restart your shell or source the config file.
+
 ---
 
 ## Key Bindings


### PR DESCRIPTION
## Summary
- Add shell completion support for bash, zsh, fish, and PowerShell
- New `taws completion <shell>` subcommand to generate completion scripts

## Usage

```bash
# Bash (add to ~/.bashrc)
eval "$(taws completion bash)"

# Zsh (add to ~/.zshrc)
eval "$(taws completion zsh)"

# Fish (add to ~/.config/fish/config.fish)
taws completion fish | source

# PowerShell (add to $PROFILE)
taws completion powershell | Out-String | Invoke-Expression
```

## Features
- Tab completion for all CLI flags (`--profile`, `--region`, `--log-level`, etc.)
- Tab completion for flag values (e.g., log levels: `off`, `error`, `warn`, `info`, `debug`, `trace`)
- Subcommand completion (`completion`, `help`)

## Example

```bash
$ taws --pr<TAB>
$ taws --profile 

$ taws --log-level <TAB>
off    error  warn   info   debug  trace

$ taws comp<TAB>
$ taws completion 

$ taws completion <TAB>
bash  zsh  fish  powershell
```

Closes #97