### PR TITLE
fix: prevent direct access to sub-resources that require parent

### DIFF
--- a/src/resource/handlers/json.rs
+++ b/src/resource/handlers/json.rs
@@ -45,7 +45,16 @@ impl JsonProtocolHandler {
                         .get(key)
                         .cloned()
                         .unwrap_or_else(|| key.clone());
-                    body.insert(mapped_key, value.clone());
+
+                    // Unwrap single-element arrays to single values
+                    // This is needed because filters are passed as arrays, but JSON protocol
+                    // APIs typically expect single values (e.g., logGroupName: "name" not ["name"])
+                    let unwrapped_value = match value {
+                        Value::Array(arr) if arr.len() == 1 => arr[0].clone(),
+                        _ => value.clone(),
+                    };
+
+                    body.insert(mapped_key, unwrapped_value);
                 }
             }
         }

--- a/src/resource/handlers/rest_json.rs
+++ b/src/resource/handlers/rest_json.rs
@@ -77,7 +77,12 @@ impl RestJsonProtocolHandler {
             if let Value::Object(map) = params {
                 for (key, value) in map {
                     if !key.starts_with('_') {
-                        body.insert(key.clone(), value.clone());
+                        // Unwrap single-element arrays to single values
+                        let unwrapped_value = match value {
+                            Value::Array(arr) if arr.len() == 1 => arr[0].clone(),
+                            _ => value.clone(),
+                        };
+                        body.insert(key.clone(), unwrapped_value);
                     }
                 }
             }

--- a/src/resource/registry.rs
+++ b/src/resource/registry.rs
@@ -194,6 +194,11 @@ pub struct ResourceDef {
     /// If present and enabled, the resource supports AWS API tag filtering
     #[serde(default)]
     pub tag_filter: Option<TagFilterConfig>,
+
+    /// If true, this resource requires a parent context and cannot be accessed directly
+    /// Used for sub-resources like Log Streams that need a Log Group
+    #[serde(default)]
+    pub requires_parent: bool,
 }
 
 impl ResourceDef {
@@ -248,11 +253,13 @@ pub fn get_resource(key: &str) -> Option<&'static ResourceDef> {
 }
 
 /// Get all resource keys (for autocomplete)
+/// Excludes resources that require a parent context (like log-streams, ecs-tasks, etc.)
 pub fn get_all_resource_keys() -> Vec<&'static str> {
     get_registry()
         .resources
-        .keys()
-        .map(|s| s.as_str())
+        .iter()
+        .filter(|(_, def)| !def.requires_parent)
+        .map(|(key, _)| key.as_str())
         .collect()
 }
 

--- a/src/resources/cloudwatch.json
+++ b/src/resources/cloudwatch.json
@@ -48,6 +48,7 @@
       "id_field": "logStreamName",
       "name_field": "logStreamName",
       "is_global": false,
+      "requires_parent": true,
       "columns": [
         { "header": "STREAM NAME", "json_path": "logStreamName", "width": 45 },
         { "header": "LAST EVENT", "json_path": "lastEventTime", "width": 22 },

--- a/src/resources/ecs.json
+++ b/src/resources/ecs.json
@@ -57,6 +57,7 @@
       "id_field": "serviceArn",
       "name_field": "serviceArn",
       "is_global": false,
+      "requires_parent": true,
       "columns": [
         { "header": "SERVICE ARN", "json_path": "serviceArn", "width": 80 }
       ],
@@ -100,6 +101,7 @@
       "id_field": "taskArn",
       "name_field": "taskArn",
       "is_global": false,
+      "requires_parent": true,
       "columns": [
         { "header": "TASK ARN", "json_path": "taskArn", "width": 80 }
       ],

--- a/src/resources/elbv2.json
+++ b/src/resources/elbv2.json
@@ -63,6 +63,7 @@
       "id_field": "ListenerArn",
       "name_field": "ListenerArn",
       "is_global": false,
+      "requires_parent": true,
       "columns": [
         { "header": "PORT", "json_path": "Port", "width": 8 },
         { "header": "PROTOCOL", "json_path": "Protocol", "width": 10 },
@@ -110,6 +111,7 @@
       "id_field": "RuleArn",
       "name_field": "RuleArn",
       "is_global": false,
+      "requires_parent": true,
       "columns": [
         { "header": "PRIORITY", "json_path": "Priority", "width": 10 },
         { "header": "IS DEFAULT", "json_path": "IsDefault", "width": 12 },
@@ -210,6 +212,7 @@
       "id_field": "TargetId",
       "name_field": "TargetId",
       "is_global": false,
+      "requires_parent": true,
       "columns": [
         { "header": "TARGET ID", "json_path": "TargetId", "width": 25 },
         { "header": "PORT", "json_path": "Port", "width": 8 },

--- a/src/resources/iam.json
+++ b/src/resources/iam.json
@@ -49,6 +49,7 @@
       "id_field": "PolicyName",
       "name_field": "PolicyName",
       "is_global": true,
+      "requires_parent": true,
       "columns": [
         { "header": "POLICY NAME", "json_path": "PolicyName", "width": 28 },
         { "header": "ARN", "json_path": "PolicyArn", "width": 34 }
@@ -77,6 +78,7 @@
       "id_field": "GroupId",
       "name_field": "GroupName",
       "is_global": true,
+      "requires_parent": true,
       "columns": [
         { "header": "GROUP NAME", "json_path": "GroupName", "width": 25 },
         { "header": "GROUP ID", "json_path": "GroupId", "width": 24 },
@@ -107,6 +109,7 @@
       "id_field": "AccessKeyId",
       "name_field": "AccessKeyId",
       "is_global": true,
+      "requires_parent": true,
       "columns": [
         { "header": "ACCESS KEY ID", "json_path": "AccessKeyId", "width": 25 },
         { "header": "STATUS", "json_path": "Status", "width": 10, "color_map": "state" },
@@ -176,6 +179,7 @@
       "id_field": "PolicyName",
       "name_field": "PolicyName",
       "is_global": true,
+      "requires_parent": true,
       "columns": [
         { "header": "POLICY NAME", "json_path": "PolicyName", "width": 28 },
         { "header": "ARN", "json_path": "PolicyArn", "width": 34 }
@@ -274,6 +278,7 @@
       "id_field": "UserId",
       "name_field": "UserName",
       "is_global": true,
+      "requires_parent": true,
       "columns": [
         { "header": "USER NAME", "json_path": "UserName", "width": 22 },
         { "header": "USER ID", "json_path": "UserId", "width": 24 },

--- a/src/resources/s3.json
+++ b/src/resources/s3.json
@@ -47,6 +47,7 @@
       "id_field": "Key",
       "name_field": "DisplayName",
       "is_global": false,
+      "requires_parent": true,
       "columns": [
         { "header": "NAME", "json_path": "DisplayName", "width": 50 },
         { "header": "SIZE", "json_path": "Size", "width": 12 },


### PR DESCRIPTION
## Summary
- Adds `requires_parent` field to `ResourceDef` to mark sub-resources that cannot be accessed directly
- Excludes `requires_parent` resources from command autocomplete suggestions
- Shows a helpful error message when user tries to access a sub-resource directly via `:command`

## Changes
- `src/resource/registry.rs`: Added `requires_parent` field and updated `get_all_resource_keys()` to filter them out
- `src/app.rs`: Added check in `execute_command()` to show error for `requires_parent` resources
- Updated JSON resource files to mark the following as `requires_parent: true`:
  - `cloudwatch-log-streams`
  - `ecs-services`, `ecs-tasks`
  - `elbv2-listeners`, `elbv2-rules`, `elbv2-targets`
  - `s3-objects`
  - `iam-user-policies`, `iam-user-groups`, `iam-access-keys`, `iam-role-policies`, `iam-group-users`

Fixes #107 and #108