### PR TITLE
fix: unwrap single-value arrays in JSON protocol handlers

### DIFF
--- a/src/resource/handlers/json.rs
+++ b/src/resource/handlers/json.rs
@@ -45,7 +45,16 @@ impl JsonProtocolHandler {
                         .get(key)
                         .cloned()
                         .unwrap_or_else(|| key.clone());
-                    body.insert(mapped_key, value.clone());
+
+                    // Unwrap single-element arrays to single values
+                    // This is needed because filters are passed as arrays, but JSON protocol
+                    // APIs typically expect single values (e.g., logGroupName: "name" not ["name"])
+                    let unwrapped_value = match value {
+                        Value::Array(arr) if arr.len() == 1 => arr[0].clone(),
+                        _ => value.clone(),
+                    };
+
+                    body.insert(mapped_key, unwrapped_value);
                 }
             }
         }

--- a/src/resource/handlers/rest_json.rs
+++ b/src/resource/handlers/rest_json.rs
@@ -77,7 +77,12 @@ impl RestJsonProtocolHandler {
             if let Value::Object(map) = params {
                 for (key, value) in map {
                     if !key.starts_with('_') {
-                        body.insert(key.clone(), value.clone());
+                        // Unwrap single-element arrays to single values
+                        let unwrapped_value = match value {
+                            Value::Array(arr) if arr.len() == 1 => arr[0].clone(),
+                            _ => value.clone(),
+                        };
+                        body.insert(key.clone(), unwrapped_value);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Unwraps single-element arrays to single values in JSON and REST-JSON protocol handlers
- Fixes the `SerializationException: "Start of list found where not expected"` error when navigating from log groups to log streams

## Root Cause
Filters are passed internally as arrays (e.g., `log_group_name: ["/aws/lambda/my-function"]`), but AWS JSON protocol APIs expect single string values (e.g., `logGroupName: "/aws/lambda/my-function"`).

## Changes
- `src/resource/handlers/json.rs`: Added logic to unwrap single-element arrays before inserting into request body
- `src/resource/handlers/rest_json.rs`: Same fix applied for consistency

Fixes #108