### PR TITLE
fix: use filter_type for sub-resource filtering

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -634,7 +634,11 @@ impl App {
                     // Extract parent ID value
                     let parent_id = extract_json_value(&parent.item, &sub.parent_id_field);
                     if parent_id != "-" {
-                        return vec![ResourceFilter::new(&sub.filter_param, vec![parent_id])];
+                        return vec![ResourceFilter::with_type(
+                            &sub.filter_param,
+                            vec![parent_id],
+                            &sub.filter_type,
+                        )];
                     }
                 }
             }

--- a/src/resource/registry.rs
+++ b/src/resource/registry.rs
@@ -71,6 +71,14 @@ pub struct SubResourceDef {
     pub shortcut: String,
     pub parent_id_field: String,
     pub filter_param: String,
+    /// Filter type: "scalar" (default) for single-value params (IAM, ELBv2, RDS),
+    /// "ec2_filter" for EC2-style Filter.N.Name/Value params (VPC subnets, security groups)
+    #[serde(default = "default_filter_type")]
+    pub filter_type: String,
+}
+
+fn default_filter_type() -> String {
+    "scalar".to_string()
 }
 
 /// Confirmation config for actions

--- a/src/resources/vpc.json
+++ b/src/resources/vpc.json
@@ -18,8 +18,8 @@
         { "header": "TENANCY", "json_path": "InstanceTenancy", "width": 12 }
       ],
       "sub_resources": [
-        { "shortcut": "s", "display_name": "Subnets", "resource_key": "subnets", "parent_id_field": "VpcId", "filter_param": "vpc_ids" },
-        { "shortcut": "g", "display_name": "Security Groups", "resource_key": "security-groups", "parent_id_field": "VpcId", "filter_param": "vpc_ids" }
+        { "shortcut": "s", "display_name": "Subnets", "resource_key": "subnets", "parent_id_field": "VpcId", "filter_param": "vpc-id", "filter_type": "ec2_filter" },
+        { "shortcut": "g", "display_name": "Security Groups", "resource_key": "security-groups", "parent_id_field": "VpcId", "filter_param": "vpc-id", "filter_type": "ec2_filter" }
       ],
       "actions": [],
       "api_config": {


### PR DESCRIPTION
## Summary

Add `filter_type` field to sub-resource definitions to correctly format filter parameters for different AWS API requirements.

- `scalar` (default): single-value params for IAM, ELBv2, RDS
- `ec2_filter`: Filter.N.Name/Value format for EC2/VPC APIs

Fixes #123