### PR TITLE
fix: enable object search in bucket resources

### DIFF
--- a/src/resource/dispatch.rs
+++ b/src/resource/dispatch.rs
@@ -136,12 +136,24 @@ pub async fn invoke_sdk(
     match (service, method) {
         // S3 list_objects_v2 - requires bucket region resolution and complex folder handling
         ("s3", "list_objects_v2") => {
+            tracing::debug!("invoke_sdk s3.list_objects_v2 params: {:#?}", params);
             let bucket = params
                 .get("bucket_names")
-                .and_then(|v| v.as_array())
-                .and_then(|arr| arr.first())
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| anyhow!("Bucket name required"))?;
+                .and_then(|v| {
+                    // Handle both String (single value) and Array (multiple values)
+                    v.as_str()
+                        .map(|s| s.to_string())
+                        .or_else(|| {
+                            v.as_array()
+                                .and_then(|arr| arr.first())
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string())
+                        })
+                })
+                .ok_or_else(|| {
+                    tracing::error!("Bucket name required - params: {:#?}", params);
+                    anyhow!("Bucket name required")
+                })?;
 
             let prefix = params
                 .get("prefix")
@@ -159,7 +171,7 @@ pub async fn invoke_sdk(
                 })
                 .unwrap_or_default();
 
-            let bucket_region = clients.http.get_bucket_region(bucket).await?;
+            let bucket_region = clients.http.get_bucket_region(&bucket).await?;
             debug!("Bucket {} is in region {}", bucket, bucket_region);
 
             let path = if prefix.is_empty() {
@@ -173,7 +185,7 @@ pub async fn invoke_sdk(
 
             let xml = clients
                 .http
-                .rest_xml_request_s3_bucket("GET", bucket, &path, None, &bucket_region)
+                .rest_xml_request_s3_bucket("GET", &bucket, &path, None, &bucket_region)
                 .await?;
             let json = xml_to_json(&xml)?;
 

--- a/src/resource/dispatch.rs
+++ b/src/resource/dispatch.rs
@@ -136,7 +136,6 @@ pub async fn invoke_sdk(
     match (service, method) {
         // S3 list_objects_v2 - requires bucket region resolution and complex folder handling
         ("s3", "list_objects_v2") => {
-            tracing::debug!("invoke_sdk s3.list_objects_v2 params: {:#?}", params);
             let bucket = params
                 .get("bucket_names")
                 .and_then(|v| {

--- a/src/resource/dispatch.rs
+++ b/src/resource/dispatch.rs
@@ -874,4 +874,24 @@ mod tests {
         let resource = get_resource("iam-users").unwrap();
         assert!(resource.has_api_config());
     }
+
+    #[test]
+    fn test_extract_param_variants() {
+        use serde_json::json;
+
+        // Test single string value
+        let params_str = json!({ "bucket": "my-bucket" });
+        assert_eq!(extract_param(&params_str, "bucket"), "my-bucket");
+
+        // Test array with single string
+        let params_single_arr = json!({ "bucket": ["only-bucket"] });
+        assert_eq!(extract_param(&params_single_arr, "bucket"), "only-bucket");
+
+        // Test array of strings (takes first)
+        let params_arr = json!({ "bucket": ["first-bucket", "second-bucket"] });
+        assert_eq!(extract_param(&params_arr, "bucket"), "first-bucket");
+
+        // Test missing key
+        assert_eq!(extract_param(&params_str, "nonexistent"), "");
+    }
 }


### PR DESCRIPTION
## Related Issue

Closes #144

## Description

Fixes S3 object navigation by improving bucket name extraction logic. Ensures list_objects_v2 handles both string and array bucket_names.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have linked this PR to an existing issue
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [ ] I have added/updated relevant documentation (if applicable)
- [ ] My changes don't introduce new warnings

## Screenshots (if applicable)

<!-- Add screenshots to demonstrate UI changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
