### PR TITLE
feat: add Redshift clusters/snapshots support and fix S3 object navigation

### DIFF
--- a/src/aws/http.rs
+++ b/src/aws/http.rs
@@ -327,6 +327,14 @@ pub fn get_service(name: &str) -> Option<ServiceDefinition> {
             target_prefix: Some("AmazonAthena"),
             is_global: false,
         }),
+        "redshift" => Some(ServiceDefinition {
+            signing_name: "redshift",
+            endpoint_prefix: "redshift",
+            api_version: "2012-12-01",
+            protocol: Protocol::Query,
+            target_prefix: None,
+            is_global: false,
+        }),
         _ => None,
     }
 }

--- a/src/resource/dispatch.rs
+++ b/src/resource/dispatch.rs
@@ -71,6 +71,13 @@ fn format_epoch_millis(millis: i64) -> String {
         .unwrap_or_else(|| "-".to_string())
 }
 
+/// Resolve template variables in static param values: {resource_id}, {timestamp}
+fn resolve_static_param_template(template: &str, resource_id: &str, timestamp: &str) -> String {
+    template
+        .replace("{resource_id}", resource_id)
+        .replace("{timestamp}", timestamp)
+}
+
 /// Format epoch milliseconds to human-readable date string (public for log tail UI)
 pub fn format_log_timestamp(millis: i64) -> String {
     format_epoch_millis(millis)
@@ -136,12 +143,10 @@ pub async fn invoke_sdk(
     match (service, method) {
         // S3 list_objects_v2 - requires bucket region resolution and complex folder handling
         ("s3", "list_objects_v2") => {
-            let bucket = params
-                .get("bucket_names")
-                .and_then(|v| v.as_array())
-                .and_then(|arr| arr.first())
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| anyhow!("Bucket name required"))?;
+            let bucket = extract_param(params, "bucket_names");
+            if bucket.is_empty() {
+                return Err(anyhow!("Bucket name required"));
+            }
 
             let prefix = params
                 .get("prefix")
@@ -159,7 +164,7 @@ pub async fn invoke_sdk(
                 })
                 .unwrap_or_default();
 
-            let bucket_region = clients.http.get_bucket_region(bucket).await?;
+            let bucket_region = clients.http.get_bucket_region(&bucket).await?;
             debug!("Bucket {} is in region {}", bucket, bucket_region);
 
             let path = if prefix.is_empty() {
@@ -173,7 +178,7 @@ pub async fn invoke_sdk(
 
             let xml = clients
                 .http
-                .rest_xml_request_s3_bucket("GET", bucket, &path, None, &bucket_region)
+                .rest_xml_request_s3_bucket("GET", &bucket, &path, None, &bucket_region)
                 .await?;
             let json = xml_to_json(&xml)?;
 
@@ -388,9 +393,14 @@ async fn invoke_action(
             }
 
             // Add static parameters
+            // Resolve template variables in static params: {resource_id}, {timestamp}
+            let current_timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%S").to_string();
+
             for (key, value) in &action_config.static_params {
-                if let Some(s) = value.as_str() {
-                    params_owned.push((key.clone(), s.to_string()));
+                if let Some(template) = value.as_str() {
+                    let resolved =
+                        resolve_static_param_template(template, resource_id, &current_timestamp);
+                    params_owned.push((key.clone(), resolved));
                 }
             }
 
@@ -861,5 +871,47 @@ mod tests {
     fn test_iam_users_has_api_config() {
         let resource = get_resource("iam-users").unwrap();
         assert!(resource.has_api_config());
+    }
+
+    #[test]
+    fn test_redshift_clusters_has_api_config() {
+        let resource = get_resource("redshift-clusters").unwrap();
+        assert!(resource.has_api_config());
+    }
+
+    #[test]
+    fn test_resolve_static_param_template_replaces_all_placeholders() {
+        let out = resolve_static_param_template(
+            "taws-{resource_id}-{timestamp}",
+            "test-cluster",
+            "20260309T143000",
+        );
+        assert_eq!(out, "taws-test-cluster-20260309T143000");
+    }
+
+    #[test]
+    fn test_resolve_static_param_template_keeps_plain_text() {
+        let out = resolve_static_param_template("fixed-value", "x", "y");
+        assert_eq!(out, "fixed-value");
+    }
+
+    #[test]
+    fn test_extract_param_variants() {
+        use serde_json::json;
+
+        // Test single string value
+        let params_str = json!({ "bucket": "my-bucket" });
+        assert_eq!(extract_param(&params_str, "bucket"), "my-bucket");
+
+        // Test array with single string
+        let params_single_arr = json!({ "bucket": ["only-bucket"] });
+        assert_eq!(extract_param(&params_single_arr, "bucket"), "only-bucket");
+
+        // Test array of strings (takes first)
+        let params_arr = json!({ "bucket": ["first-bucket", "second-bucket"] });
+        assert_eq!(extract_param(&params_arr, "bucket"), "first-bucket");
+
+        // Test missing key
+        assert_eq!(extract_param(&params_str, "nonexistent"), "");
     }
 }

--- a/src/resource/handlers/json.rs
+++ b/src/resource/handlers/json.rs
@@ -101,7 +101,6 @@ impl ProtocolHandler for JsonProtocolHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn test_parse_dynamodb_response() {

--- a/src/resource/handlers/query.rs
+++ b/src/resource/handlers/query.rs
@@ -206,12 +206,9 @@ impl ProtocolHandler for QueryProtocolHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn test_parse_ec2_response() {
-        let handler = QueryProtocolHandler;
-
         // Simulated EC2 DescribeInstances XML-to-JSON response
         let response = r#"
         {

--- a/src/resource/handlers/rest_json.rs
+++ b/src/resource/handlers/rest_json.rs
@@ -136,7 +136,6 @@ impl ProtocolHandler for RestJsonProtocolHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn test_parse_lambda_functions_response() {
@@ -181,5 +180,98 @@ mod tests {
 
         assert_eq!(items.len(), 2);
         assert_eq!(items[0], "cluster1");
+    }
+
+    #[test]
+    fn test_parse_redshift_clusters_response() {
+        let response = r#"{
+            "clusters": [
+                {
+                    "ClusterIdentifier": "my-cluster",
+                    "ClusterStatus": "available",
+                    "NodeType": "dc2.large",
+                    "NumberOfNodes": 2,
+                    "DBName": "mydb",
+                    "ClusterVersion": "1.0"
+                },
+                {
+                    "ClusterIdentifier": "my-cluster-2",
+                    "ClusterStatus": "paused",
+                    "NodeType": "ra3.xlplus",
+                    "NumberOfNodes": 4,
+                    "DBName": "devdb",
+                    "ClusterVersion": "1.0"
+                }
+            ],
+            "NextToken": "next123"
+        }"#;
+
+        let config = ApiConfig {
+            response_root: Some("/clusters".to_string()),
+            pagination: Some(crate::resource::protocol::PaginationConfig {
+                output_token: Some("/NextToken".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let handler = RestJsonProtocolHandler;
+        let (items, next_token) = handler.parse_items(response, &config).unwrap();
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["ClusterIdentifier"], "my-cluster");
+        assert_eq!(items[0]["ClusterStatus"], "available");
+        assert_eq!(items[0]["NodeType"], "dc2.large");
+        assert_eq!(items[0]["NumberOfNodes"], 2);
+        assert_eq!(items[0]["DBName"], "mydb");
+        assert_eq!(items[0]["ClusterVersion"], "1.0");
+        assert_eq!(items[1]["ClusterIdentifier"], "my-cluster-2");
+        assert_eq!(items[1]["ClusterStatus"], "paused");
+        assert_eq!(next_token, Some("next123".to_string()));
+    }
+
+    #[test]
+    fn test_parse_redshift_snapshots_response() {
+        let response = r#"{
+            "snapshots": [
+                {
+                    "SnapshotIdentifier": "my-cluster-snapshot-1",
+                    "Status": "available",
+                    "SnapshotType": "automated",
+                    "ClusterIdentifier": "my-cluster",
+                    "SnapshotCreateTime": "2024-01-01T00:00:00Z"
+                },
+                {
+                    "SnapshotIdentifier": "my-cluster-snapshot-2",
+                    "Status": "available",
+                    "SnapshotType": "manual",
+                    "ClusterIdentifier": "my-cluster",
+                    "SnapshotCreateTime": "2024-01-02T00:00:00Z"
+                }
+            ],
+            "NextToken": "next456"
+        }"#;
+
+        let config = ApiConfig {
+            response_root: Some("/snapshots".to_string()),
+            pagination: Some(crate::resource::protocol::PaginationConfig {
+                output_token: Some("/NextToken".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let handler = RestJsonProtocolHandler;
+        let (items, next_token) = handler.parse_items(response, &config).unwrap();
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["SnapshotIdentifier"], "my-cluster-snapshot-1");
+        assert_eq!(items[0]["Status"], "available");
+        assert_eq!(items[0]["SnapshotType"], "automated");
+        assert_eq!(items[0]["ClusterIdentifier"], "my-cluster");
+        assert_eq!(items[0]["SnapshotCreateTime"], "2024-01-01T00:00:00Z");
+        assert_eq!(items[1]["SnapshotIdentifier"], "my-cluster-snapshot-2");
+        assert_eq!(items[1]["SnapshotType"], "manual");
+        assert_eq!(next_token, Some("next456".to_string()));
     }
 }

--- a/src/resource/registry.rs
+++ b/src/resource/registry.rs
@@ -36,6 +36,7 @@ const RESOURCE_FILES: &[&str] = &[
     include_str!("../resources/kms.json"),
     include_str!("../resources/lambda.json"),
     include_str!("../resources/rds.json"),
+    include_str!("../resources/redshift.json"),
     include_str!("../resources/route53.json"),
     include_str!("../resources/s3.json"),
     include_str!("../resources/secretsmanager.json"),

--- a/src/resources/redshift.json
+++ b/src/resources/redshift.json
@@ -1,0 +1,125 @@
+{
+  "resources": {
+    "redshift-clusters": {
+      "display_name": "Redshift Clusters",
+      "service": "redshift",
+      "sdk_method": "describe_clusters",
+      "sdk_method_params": {},
+      "response_path": "clusters",
+      "id_field": "ClusterIdentifier",
+      "name_field": "ClusterIdentifier",
+      "is_global": false,
+      "columns": [
+        { "header": "CLUSTER IDENTIFIER", "json_path": "ClusterIdentifier", "width": 25 },
+        { "header": "STATUS", "json_path": "ClusterStatus", "width": 15, "color_map": "state" },
+        { "header": "NODE TYPE", "json_path": "NodeType", "width": 15 },
+        { "header": "NODES", "json_path": "NumberOfNodes", "width": 8 },
+        { "header": "DB NAME", "json_path": "DBName", "width": 15 },
+        { "header": "VERSION", "json_path": "ClusterVersion", "width": 10 }
+      ],
+      "sub_resources": [
+        { "shortcut": "n", "display_name": "Snapshots", "resource_key": "redshift-snapshots", "parent_id_field": "ClusterIdentifier", "filter_param": "cluster_identifier" }
+      ],
+      "actions": [
+        { "key": "s", "display_name": "Resume", "shortcut": "s", "sdk_method": "resume_cluster", "confirm": { "message": "Resume Redshift cluster", "default_yes": false } },
+        { "key": "S", "display_name": "Pause", "shortcut": "S", "sdk_method": "pause_cluster", "confirm": { "message": "Pause Redshift cluster", "default_yes": false } },
+        { "key": "r", "display_name": "Reboot", "shortcut": "r", "sdk_method": "reboot_cluster", "confirm": { "message": "Reboot Redshift cluster", "default_yes": false } },
+        { "key": "ctrl+d", "display_name": "Delete", "shortcut": "ctrl+d", "sdk_method": "delete_cluster", "confirm": { "message": "Delete Redshift cluster", "default_yes": false, "destructive": true } }
+      ],
+      "api_config": {
+        "protocol": "query",
+        "action": "DescribeClusters",
+        "response_root": "/DescribeClustersResponse/DescribeClustersResult/Clusters/Cluster"
+      },
+      "field_mappings": {
+        "ClusterIdentifier": { "source": "/ClusterIdentifier", "default": "-" },
+        "ClusterStatus": { "source": "/ClusterStatus", "default": "-" },
+        "NodeType": { "source": "/NodeType", "default": "-" },
+        "NumberOfNodes": { "source": "/NumberOfNodes", "default": "0" },
+        "DBName": { "source": "/DBName", "default": "-" },
+        "ClusterVersion": { "source": "/ClusterVersion", "default": "-" },
+        "Endpoint": { "source": "/Endpoint/Address", "default": "-" }
+      },
+      "action_configs": {
+        "resume_cluster": {
+          "action_id": "resume_cluster",
+          "protocol": "query",
+          "action": "ResumeCluster",
+          "id_param": "ClusterIdentifier"
+        },
+        "pause_cluster": {
+          "action_id": "pause_cluster",
+          "protocol": "query",
+          "action": "PauseCluster",
+          "id_param": "ClusterIdentifier"
+        },
+        "reboot_cluster": {
+          "action_id": "reboot_cluster",
+          "protocol": "query",
+          "action": "RebootCluster",
+          "id_param": "ClusterIdentifier"
+        },
+        "delete_cluster": {
+          "action_id": "delete_cluster",
+          "protocol": "query",
+          "action": "DeleteCluster",
+          "id_param": "ClusterIdentifier",
+          "static_params": {
+            "SkipFinalClusterSnapshot": "false",
+            "FinalClusterSnapshotIdentifier": "taws-{resource_id}-{timestamp}"
+          }
+        }
+      },
+      "describe_config": {
+        "protocol": "query",
+        "action": "DescribeClusters",
+        "id_param": "ClusterIdentifier",
+        "response_path": "/DescribeClustersResponse/DescribeClustersResult/Clusters/Cluster"
+      }
+    },
+    "redshift-snapshots": {
+      "display_name": "Redshift Snapshots",
+      "service": "redshift",
+      "sdk_method": "describe_cluster_snapshots",
+      "sdk_method_params": {},
+      "response_path": "snapshots",
+      "id_field": "SnapshotIdentifier",
+      "name_field": "SnapshotIdentifier",
+      "is_global": false,
+      "columns": [
+        { "header": "SNAPSHOT ID", "json_path": "SnapshotIdentifier", "width": 35 },
+        { "header": "STATUS", "json_path": "Status", "width": 12, "color_map": "state" },
+        { "header": "TYPE", "json_path": "SnapshotType", "width": 12 },
+        { "header": "CLUSTER", "json_path": "ClusterIdentifier", "width": 20 },
+        { "header": "CREATED", "json_path": "SnapshotCreateTime", "width": 20 }
+      ],
+      "sub_resources": [],
+      "actions": [
+        { "key": "ctrl+d", "display_name": "Delete Snapshot", "shortcut": "ctrl+d", "sdk_method": "delete_cluster_snapshot", "confirm": { "message": "Delete Redshift snapshot", "default_yes": false, "destructive": true } }
+      ],
+      "api_config": {
+        "protocol": "query",
+        "action": "DescribeClusterSnapshots",
+        "response_root": "/DescribeClusterSnapshotsResponse/DescribeClusterSnapshotsResult/Snapshots/Snapshot",
+        "param_mapping": {
+          "cluster_identifier": "ClusterIdentifier"
+        }
+      },
+      "field_mappings": {
+        "SnapshotIdentifier": { "source": "/SnapshotIdentifier", "default": "-" },
+        "ClusterIdentifier": { "source": "/ClusterIdentifier", "default": "-" },
+        "Status": { "source": "/Status", "default": "-" },
+        "SnapshotType": { "source": "/SnapshotType", "default": "-" },
+        "SnapshotCreateTime": { "source": "/SnapshotCreateTime", "default": "-" }
+      },
+      "action_configs": {
+        "delete_cluster_snapshot": {
+          "action_id": "delete_cluster_snapshot",
+          "protocol": "query",
+          "action": "DeleteClusterSnapshot",
+          "id_param": "SnapshotIdentifier"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Clean reimplementation combining the work from #142 and #145, with all review feedback addressed in a single commit.

## What's included

### Redshift support (replaces #142, closes #143)
- Add Redshift service definition (`redshift`, Query protocol, API version `2012-12-01`)
- Add `redshift.json` resource config with clusters and snapshots
- Cluster actions: Resume, Pause, Reboot, Delete
- Delete uses `SkipFinalClusterSnapshot=false` (AWS default to prevent data loss) with auto-generated `FinalClusterSnapshotIdentifier` via `taws-{resource_id}-{timestamp}` template
- Add `resolve_static_param_template()` for `{resource_id}` / `{timestamp}` variable resolution in static action params
- Snapshots as sub-resource of clusters with delete action
- Describe config for cluster details

### S3 object navigation fix (replaces #145, closes #144)
- Fix `list_objects_v2` bucket name extraction to reuse the existing `extract_param()` helper instead of duplicating string/array handling inline

### Cleanup
- Remove unused `serde_json::json` imports in test modules (`json.rs`, `query.rs`, `rest_json.rs`)
- Remove unused `handler` variable in `query.rs` test

### Tests
- Redshift clusters and snapshots response parsing tests
- `resolve_static_param_template` tests (placeholder replacement + plain text passthrough)
- `extract_param` tests (string, single-element array, multi-element array, missing key)
- Redshift resource registry test

## Review feedback addressed
| PR | Feedback | Resolution |
|---|---|---|
| #142 | `SkipFinalClusterSnapshot` should default to `false` | Set to `"false"` with required `FinalClusterSnapshotIdentifier` |
| #142 | Template syntax `${resource_id}` doesn't match code `{resource_id}` | Use `{resource_id}` consistently in both JSON and code |
| #142 | `error_message` logic change was unnecessary | Not included (no changes to `app.rs`) |
| #142 | Unused imports/variables | Cleaned up |
| #145 | `extract_param` already exists, don't duplicate | Reuse existing `extract_param()` for S3 bucket name |