### PR TITLE
add flake.nix + maintainment script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,27 @@ sudo mv taws /usr/local/bin/
 2. Extract the zip file
 3. Add the extracted folder to your PATH, or move `taws.exe` to a directory in your PATH
 
+### Nix
+
+```bash
+# Run directly
+nix run github:huseyinbabal/taws
+
+# Try it in a temporary shell
+nix shell github:huseyinbabal/taws
+taws --version
+
+# Build from source
+nix build
+nix run . -- --version
+
+# Development shell with Rust tooling
+nix develop
+cargo build
+```
+
+> **Maintaining the flake?** See [docs/maintaining-nix-flake.md](docs/maintaining-nix-flake.md) for updating versions, hashes, and nixpkgs.
+
 ### Using Cargo
 
 ```bash

--- a/docs/maintaining-nix-flake.md
+++ b/docs/maintaining-nix-flake.md
@@ -1,0 +1,56 @@
+# Maintaining the Nix Flake
+
+## Quick start
+
+Use `scripts/update-flake.sh` to automate all maintenance tasks:
+
+```bash
+# Run everything (sync version, update hash, update lock, verify)
+./scripts/update-flake.sh
+
+# Or run individual steps
+./scripts/update-flake.sh sync-version   # Sync version from Cargo.toml to flake.nix
+./scripts/update-flake.sh update-hash    # Recalculate cargoHash
+./scripts/update-flake.sh update-lock    # Update flake.lock (nixpkgs pin)
+./scripts/update-flake.sh check          # Run full verification checklist
+```
+
+## What each command does
+
+### `sync-version`
+
+Reads the version from `Cargo.toml` and updates it in `flake.nix`. Run this after bumping the crate version.
+
+### `update-hash`
+
+Recalculates `cargoHash` in `flake.nix`. This is needed whenever `Cargo.lock` changes (new/updated dependencies). The script:
+
+1. Clears the hash to trigger a mismatch
+2. Runs `nix build` and extracts the correct hash from the error output
+3. Writes the new hash back into `flake.nix`
+4. Verifies the build succeeds
+
+### `update-lock`
+
+Runs `nix flake update` to pin a newer version of nixpkgs. Do this periodically to pick up newer Rust toolchains and fixes.
+
+### `check`
+
+Runs the full verification checklist:
+
+```bash
+nix build --no-link           # Build succeeds
+nix run . -- --version        # Binary runs correctly
+nix flake check               # Flake structure is valid
+nix develop -c cargo --version  # Dev shell works
+```
+
+## Manual steps (if needed)
+
+To update `cargoHash` manually:
+
+1. Set `cargoHash = "";` in `flake.nix`
+2. Run `nix build --no-link 2>&1`
+3. Copy the hash from the `got:` line in the error output
+4. Replace the empty string with the new hash
+5. Run `nix build --no-link` to verify

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "taws - Terminal UI for AWS";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f {
+        inherit system;
+        pkgs = nixpkgs.legacyPackages.${system};
+      });
+    in
+    {
+      packages = forAllSystems ({ pkgs, ... }: {
+        default = pkgs.rustPlatform.buildRustPackage {
+          pname = "taws";
+          version = "1.3.0-rc.7";
+          src = ./.;
+          cargoHash = "sha256-7zZ2JJVQem2R072sefv2oB9mmQcRuUHVKKcb+HEnm6Y=";
+          meta = {
+            description = "Terminal UI for AWS - navigate, observe, and manage AWS resources";
+            homepage = "https://github.com/huseyinbabal/taws";
+            license = pkgs.lib.licenses.mit;
+            mainProgram = "taws";
+          };
+        };
+      });
+
+      apps = forAllSystems ({ system, ... }: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/taws";
+          meta.description = "Terminal UI for AWS";
+        };
+      });
+
+      devShells = forAllSystems ({ pkgs, ... }: {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            cargo
+            rustc
+            rust-analyzer
+            rustfmt
+            clippy
+          ];
+          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+        };
+      });
+    };
+}

--- a/scripts/update-flake.sh
+++ b/scripts/update-flake.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FLAKE_NIX="flake.nix"
+CARGO_TOML="Cargo.toml"
+
+cd "$(git rev-parse --show-toplevel)"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [command]
+
+Commands:
+  sync-version   Sync version from Cargo.toml into flake.nix
+  update-hash    Recalculate cargoHash in flake.nix
+  update-lock    Run nix flake update
+  check          Run the full verification checklist
+  all            Run sync-version + update-hash + update-lock + check
+
+If no command is given, runs 'all'.
+EOF
+}
+
+sync_version() {
+  local cargo_version
+  cargo_version=$(sed -n 's/^version *= *"\(.*\)"/\1/p' "$CARGO_TOML" | head -1)
+  if [[ -z "$cargo_version" ]]; then
+    echo "ERROR: Could not read version from $CARGO_TOML" >&2
+    exit 1
+  fi
+
+  local flake_version
+  flake_version=$(sed -n 's/.*version = "\(.*\)";/\1/p' "$FLAKE_NIX" | head -1)
+
+  if [[ "$cargo_version" == "$flake_version" ]]; then
+    echo "Version already in sync: $cargo_version"
+  else
+    sed -i "s/version = \"${flake_version}\";/version = \"${cargo_version}\";/" "$FLAKE_NIX"
+    echo "Updated flake.nix version: $flake_version -> $cargo_version"
+  fi
+}
+
+update_hash() {
+  # Clear the hash to force a mismatch
+  sed -i 's/cargoHash = "sha256-.*";/cargoHash = "";/' "$FLAKE_NIX"
+
+  echo "Building to calculate cargoHash (this may take a while)..."
+  local build_output
+  build_output=$(nix build --no-link 2>&1) && {
+    echo "Build succeeded with empty hash — cargoHash may already be correct."
+    return 0
+  }
+
+  local new_hash
+  new_hash=$(echo "$build_output" | sed -n 's/.*got: *\(sha256-.*\)/\1/p' | head -1)
+
+  if [[ -z "$new_hash" ]]; then
+    echo "ERROR: Could not extract hash from build output:" >&2
+    echo "$build_output" >&2
+    exit 1
+  fi
+
+  sed -i "s|cargoHash = \"\";|cargoHash = \"${new_hash}\";|" "$FLAKE_NIX"
+  echo "Updated cargoHash: $new_hash"
+
+  echo "Verifying build..."
+  nix build --no-link
+  echo "Build verified."
+}
+
+update_lock() {
+  echo "Updating flake.lock..."
+  nix flake update
+  echo "flake.lock updated."
+}
+
+check() {
+  echo "Running verification checklist..."
+
+  echo "  nix build --no-link"
+  nix build --no-link
+
+  echo "  nix run . -- --version"
+  nix run . -- --version
+
+  echo "  nix flake check"
+  nix flake check
+
+  echo "  nix develop -c cargo --version"
+  nix develop -c cargo --version
+
+  echo "All checks passed."
+}
+
+cmd="${1:-all}"
+
+case "$cmd" in
+  sync-version) sync_version ;;
+  update-hash)  update_hash ;;
+  update-lock)  update_lock ;;
+  check)        check ;;
+  all)
+    sync_version
+    update_hash
+    update_lock
+    check
+    ;;
+  -h|--help|help) usage ;;
+  *)
+    echo "Unknown command: $cmd" >&2
+    usage >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Related Issue

Closes #158

## Description

The flake uses native Nix multi-system iteration (no extra inputs beyond nixpkgs-unstable). The dev shell includes cargo, rustc, rust-analyzer, rustfmt, and clippy with `RUST_SRC_PATH` set for IDE support.

The maintenance script (`scripts/update-flake.sh`) automates the tedious parts of flake upkeep — syncing versions from Cargo.toml, recalculating `cargoHash` after dependency changes, and running the full verification checklist.

## Summary

- Add `flake.nix` with `rustPlatform.buildRustPackage` derivation for taws
- Support all four standard Nix systems (x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin)
- Provide default package, app, and devShell outputs (no flake-utils dependency)
- Add `scripts/update-flake.sh` to automate version sync, hash recalculation, lock updates, and verification
- Add Nix installation section to README
- Add `docs/maintaining-nix-flake.md` for maintainers

### Test plan

- [x] `nix build --no-link` succeeds
- [x] `nix run . -- --version` outputs `taws 1.3.0-rc.7`
- [x] `nix flake check` passes
- [x] `nix develop -c cargo --version` works

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have linked this PR to an existing issue
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] I have added/updated relevant documentation (if applicable)
- [x] My changes don't introduce new warnings

## Screenshots (if applicable)

<!-- Add screenshots to demonstrate UI changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
