### PR TITLE
feat: ssm param values

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -699,7 +699,7 @@ impl App {
                 .collect();
 
             // Sort by score descending (higher score = better match)
-            scored_items.sort_by(|a, b| b.0.cmp(&a.0));
+            scored_items.sort_by_key(|b| std::cmp::Reverse(b.0));
 
             // Extract just the items
             self.filtered_items = scored_items.into_iter().map(|(_, item)| item).collect();

--- a/src/event.rs
+++ b/src/event.rs
@@ -354,13 +354,12 @@ async fn handle_filter_input(app: &mut App, key: KeyEvent) -> Result<bool> {
             app.filter_active = false;
             app.filters_autocomplete_shown = false;
         }
-        KeyCode::Tab => {
+        KeyCode::Tab
             // Autocomplete "Filters:" when typing F/Fi/Filters
-            if app.should_show_filters_autocomplete() {
+            if app.should_show_filters_autocomplete() => {
                 app.filter_text = "Filters: ".to_string();
                 app.filters_autocomplete_shown = false;
             }
-        }
         KeyCode::Backspace => {
             app.filter_text.pop();
             // Update autocomplete state

--- a/src/resource/dispatch.rs
+++ b/src/resource/dispatch.rs
@@ -737,6 +737,24 @@ pub async fn execute_action_with_result(
             Ok(json)
         }
 
+        // SSM - Get Parameter Value (with decryption for SecureString)
+        ("ssm", "get_parameter") => {
+            let response = clients
+                .http
+                .json_request(
+                    "ssm",
+                    "GetParameter",
+                    &json!({
+                        "Name": resource_id,
+                        "WithDecryption": true
+                    })
+                    .to_string(),
+                )
+                .await?;
+            let json: Value = serde_json::from_str(&response)?;
+            Ok(json)
+        }
+
         _ => Err(anyhow!(
             "Unknown action with result: {}.{}",
             service,

--- a/src/resource/registry.rs
+++ b/src/resource/registry.rs
@@ -613,4 +613,33 @@ mod tests {
             "get_secret_value should use 'x' shortcut"
         );
     }
+
+    #[test]
+    fn test_ssm_parameters_has_view_value_action() {
+        let resource = get_resource("ssm-parameters").unwrap();
+        assert!(
+            !resource.actions.is_empty(),
+            "SSM Parameters should have actions"
+        );
+
+        let view_action = resource
+            .actions
+            .iter()
+            .find(|a| a.sdk_method == "get_parameter");
+        assert!(
+            view_action.is_some(),
+            "SSM Parameters should have get_parameter action"
+        );
+
+        let view_action = view_action.unwrap();
+        assert!(
+            view_action.show_result,
+            "get_parameter action should have show_result=true"
+        );
+        assert_eq!(
+            view_action.shortcut.as_deref(),
+            Some("x"),
+            "get_parameter should use 'x' shortcut"
+        );
+    }
 }

--- a/src/resources/ssm.json
+++ b/src/resources/ssm.json
@@ -16,7 +16,9 @@
         { "header": "LAST MODIFIED", "json_path": "LastModifiedDate", "width": 25 }
       ],
       "sub_resources": [],
-      "actions": [],
+      "actions": [
+        { "key": "x", "display_name": "View Parameter Value", "shortcut": "x", "sdk_method": "get_parameter", "show_result": true }
+      ],
       "api_config": {
         "protocol": "json",
         "action": "DescribeParameters",


### PR DESCRIPTION
## Related Issue

Closes #155 #160 

## Description

This merge request adds the ability to view an SSM Parameter value by pressing `x`, similar to how the functionality works in Secrets.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have linked this PR to an existing issue
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] I have added/updated relevant documentation (if applicable)
- [x] My changes don't introduce new warnings

## Screenshots (if applicable)

<img width="1427" height="329" alt="image" src="https://github.com/user-attachments/assets/babee88c-a4bd-4c79-86b8-b357051d4fe0" />


## Additional Notes

N/A
