### PR TITLE
feat: add copy-to-clipboard hotkey for SSM parameter and secret values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +87,26 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
 
 [[package]]
 name = "async-trait"
@@ -306,6 +332,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +445,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +519,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +568,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -672,6 +728,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +809,21 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -766,6 +853,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -863,6 +960,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +1007,17 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1218,6 +1336,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1599,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1618,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1552,6 +1704,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1741,6 +1966,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +2026,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -2342,6 +2592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,6 +2723,7 @@ name = "taws"
 version = "1.3.0-rc.8"
 dependencies = [
  "anyhow",
+ "arboard",
  "async-trait",
  "aws-credential-types",
  "aws-sigv4",
@@ -2619,6 +2876,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3122,6 +3393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3531,6 +3808,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,3 +3932,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ sha2 = "0.10"
 open = "5.3"
 fuzzy-matcher = "0.3.7"
 async-trait = "0.1.89"
+arboard = "3.6"
 
 [dev-dependencies]
 dirs = "6.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1250,8 +1250,7 @@ impl App {
                         self.status_message = Some(format!("{} copied to clipboard", label));
                     }
                     Err(e) => {
-                        self.error_message =
-                            Some(format!("Failed to copy to clipboard: {}", e));
+                        self.error_message = Some(format!("Failed to copy to clipboard: {}", e));
                     }
                 }
             }
@@ -1959,10 +1958,7 @@ mod tests {
             "VersionId": "abc-123"
         });
         let result = extract_copyable_value("secretsmanager-secrets", &data);
-        assert_eq!(
-            result,
-            Some("{\"key\":\"fake-data\"}".to_string())
-        );
+        assert_eq!(result, Some("{\"key\":\"fake-data\"}".to_string()));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -152,6 +152,7 @@ pub struct App {
     // UI state
     pub loading: bool,
     pub error_message: Option<String>,
+    pub status_message: Option<String>, // Transient success/info message (not an error)
     pub describe_scroll: usize,
     pub describe_data: Option<Value>, // Full resource details from describe API
     pub last_action_display_name: Option<String>,
@@ -373,6 +374,7 @@ impl App {
             pending_action: None,
             loading: false,
             error_message: None,
+            status_message: None,
             describe_scroll: 0,
             describe_data: None,
             last_action_display_name: None,
@@ -1219,6 +1221,46 @@ impl App {
         self.last_action_display_name = None;
     }
 
+    /// Copy the primary value from the current action result view to the clipboard.
+    /// Only works when viewing an action result (e.g., after pressing 'x' to view a value).
+    /// For SSM parameters, copies the Parameter Value.
+    /// For Secrets Manager secrets, copies the SecretString.
+    pub fn copy_describe_value_to_clipboard(&mut self) {
+        // Only allow copy in action result views (not regular describe)
+        if self.last_action_display_name.is_none() {
+            return;
+        }
+
+        let Some(ref data) = self.describe_data else {
+            self.error_message = Some("No data to copy".to_string());
+            return;
+        };
+
+        let value_to_copy = extract_copyable_value(&self.current_resource_key, data);
+
+        match value_to_copy {
+            Some(text) if !text.is_empty() => {
+                match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(&text)) {
+                    Ok(_) => {
+                        let label = if self.current_resource_key == "ssm-parameters" {
+                            "Parameter value"
+                        } else {
+                            "Secret value"
+                        };
+                        self.status_message = Some(format!("{} copied to clipboard", label));
+                    }
+                    Err(e) => {
+                        self.error_message =
+                            Some(format!("Failed to copy to clipboard: {}", e));
+                    }
+                }
+            }
+            _ => {
+                self.error_message = Some("No value found to copy".to_string());
+            }
+        }
+    }
+
     // =========================================================================
     // Resource Navigation
     // =========================================================================
@@ -1798,6 +1840,26 @@ impl App {
     }
 }
 
+/// Extract the copyable value from describe data based on resource type.
+/// Returns None for unsupported resource types.
+fn extract_copyable_value(resource_key: &str, data: &Value) -> Option<String> {
+    match resource_key {
+        "ssm-parameters" => {
+            // SSM GetParameter response: { "Parameter": { "Value": "..." } }
+            data.pointer("/Parameter/Value")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        }
+        "secretsmanager-secrets" => {
+            // GetSecretValue response: { "SecretString": "..." }
+            data.pointer("/SecretString")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        }
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1872,5 +1934,64 @@ mod tests {
             filters.display(),
             "Filters: owner=amazon, architecture=arm64"
         );
+    }
+
+    #[test]
+    fn test_extract_copyable_value_ssm_parameter() {
+        let data = serde_json::json!({
+            "Parameter": {
+                "Name": "/app/config-key",
+                "Type": "SecureString",
+                "Value": "fake-data",
+                "Version": 1
+            }
+        });
+        let result = extract_copyable_value("ssm-parameters", &data);
+        assert_eq!(result, Some("fake-data".to_string()));
+    }
+
+    #[test]
+    fn test_extract_copyable_value_secretsmanager() {
+        let data = serde_json::json!({
+            "ARN": "arn:aws:secretsmanager:us-east-1:123456789:secret:my-secret",
+            "Name": "my-secret",
+            "SecretString": "{\"key\":\"fake-data\"}",
+            "VersionId": "abc-123"
+        });
+        let result = extract_copyable_value("secretsmanager-secrets", &data);
+        assert_eq!(
+            result,
+            Some("{\"key\":\"fake-data\"}".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_copyable_value_unsupported_resource() {
+        let data = serde_json::json!({"InstanceId": "i-12345"});
+        let result = extract_copyable_value("ec2-instances", &data);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_extract_copyable_value_ssm_missing_value_field() {
+        let data = serde_json::json!({
+            "Parameter": {
+                "Name": "/app/config",
+                "Type": "String"
+            }
+        });
+        let result = extract_copyable_value("ssm-parameters", &data);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_extract_copyable_value_secret_missing_secret_string() {
+        let data = serde_json::json!({
+            "ARN": "arn:aws:secretsmanager:us-east-1:123456789:secret:binary-secret",
+            "Name": "binary-secret",
+            "SecretBinary": "base64data"
+        });
+        let result = extract_copyable_value("secretsmanager-secrets", &data);
+        assert_eq!(result, None);
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -437,6 +437,9 @@ fn handle_help_mode(app: &mut App, key: KeyEvent) -> Result<bool> {
 }
 
 fn handle_describe_mode(app: &mut App, key: KeyEvent) -> Result<bool> {
+    // Clear transient status message on any keypress
+    app.status_message = None;
+
     // If search input is active, handle text input
     if app.describe_search_active {
         return handle_describe_search_input(app, key);
@@ -498,6 +501,10 @@ fn handle_describe_mode(app: &mut App, key: KeyEvent) -> Result<bool> {
         // Go to bottom
         KeyCode::Char('G') | KeyCode::End => {
             app.describe_scroll_to_bottom(40);
+        }
+        // Copy value to clipboard
+        KeyCode::Char('c') => {
+            app.copy_describe_value_to_clipboard();
         }
         _ => {}
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -766,6 +766,8 @@ fn render_crumb(f: &mut Frame, app: &App, area: Rect) {
 
     let status_text = if let Some(err) = &app.error_message {
         format!("Error: {}", err)
+    } else if let Some(msg) = &app.status_message {
+        msg.clone()
     } else if app.loading {
         "Loading...".to_string()
     } else if app.mode == Mode::Describe {
@@ -773,6 +775,8 @@ fn render_crumb(f: &mut Frame, app: &App, area: Rect) {
             "Type to search | Enter: confirm | Esc: cancel".to_string()
         } else if !app.describe_search_text.is_empty() {
             "n/N: next/prev match | /: new search | Esc: clear".to_string()
+        } else if app.last_action_display_name.is_some() {
+            "j/k: scroll | /: search | c: copy value | q/d/Esc: back".to_string()
         } else {
             "j/k: scroll | /: search | q/d/Esc: back".to_string()
         }
@@ -799,6 +803,8 @@ fn render_crumb(f: &mut Frame, app: &App, area: Rect) {
 
     let style = if app.error_message.is_some() {
         Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+    } else if app.status_message.is_some() {
+        Style::default().fg(Color::Green)
     } else if app.loading {
         Style::default().fg(Color::Yellow)
     } else {


### PR DESCRIPTION
Add 'c' keybinding in the action result view (after pressing 'x' to reveal a value) that copies the value to the system clipboard.

- SSM Parameters: copies the decrypted parameter value
- Secrets Manager: copies the secret string

Uses the arboard crate for cross-platform clipboard support. The hotkey only appears in action result views, not regular describe. Success feedback shown in green in the status bar.

## Related Issue

Closes #168 

## Description

Adds capability to easily copy a secret or parameter to local clipboard on keypress.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have linked this PR to an existing issue
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] I have added/updated relevant documentation (if applicable)
- [x] My changes don't introduce new warnings

## Screenshots (if applicable)

<img width="684" height="76" alt="image" src="https://github.com/user-attachments/assets/2bcbd6e7-e0f5-427b-ab84-3add48fd8dd0" />
<img width="497" height="64" alt="image" src="https://github.com/user-attachments/assets/01d6682f-ad99-41e8-8080-26c801fe187e" />
