### PR TITLE
fix: make ] / [ pagination work across resources

### DIFF
--- a/src/resource/handlers/json.rs
+++ b/src/resource/handlers/json.rs
@@ -59,6 +59,19 @@ impl JsonProtocolHandler {
             }
         }
 
+        // Add pagination params last so a page token always wins over static/dynamic params
+        if let Some(pagination) = &config.pagination {
+            if let Some(max_param) = &pagination.max_results_param {
+                let max_value = pagination.max_results.unwrap_or(100);
+                body.insert(max_param.clone(), Value::from(max_value));
+            }
+            if let Some(token) = params.get("_page_token").and_then(|v| v.as_str()) {
+                if let Some(input_token) = &pagination.input_token {
+                    body.insert(input_token.clone(), Value::String(token.to_string()));
+                }
+            }
+        }
+
         let body_str = serde_json::to_string(&Value::Object(body))?;
         clients.http.json_request(service, action, &body_str).await
     }

--- a/src/resource/handlers/rest_xml.rs
+++ b/src/resource/handlers/rest_xml.rs
@@ -57,6 +57,14 @@ impl RestXmlProtocolHandler {
             }
         }
 
+        // Add max results if configured
+        if let Some(pagination) = &config.pagination {
+            if let Some(max_param) = &pagination.max_results_param {
+                let max_value = pagination.max_results.unwrap_or(100);
+                query_parts.push(format!("{}={}", max_param, max_value));
+            }
+        }
+
         if !query_parts.is_empty() {
             if path.contains('?') {
                 path = format!("{}&{}", path, query_parts.join("&"));

--- a/src/resources/acm.json
+++ b/src/resources/acm.json
@@ -20,7 +20,13 @@
       "api_config": {
         "protocol": "json",
         "action": "ListCertificates",
-        "response_root": "/CertificateSummaryList"
+        "response_root": "/CertificateSummaryList",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/NextToken",
+          "max_results_param": "MaxItems",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "DomainName": { "source": "/DomainName", "default": "-" },

--- a/src/resources/apigateway.json
+++ b/src/resources/apigateway.json
@@ -21,7 +21,13 @@
         "protocol": "rest-json",
         "method": "GET",
         "path": "/restapis",
-        "response_root": "/item"
+        "response_root": "/item",
+        "pagination": {
+          "input_token": "position",
+          "output_token": "/position",
+          "max_results_param": "limit",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "id": { "source": "/id", "default": "-" },

--- a/src/resources/athena.json
+++ b/src/resources/athena.json
@@ -19,7 +19,13 @@
       "api_config": {
         "protocol": "json",
         "action": "ListWorkGroups",
-        "response_root": "/WorkGroups"
+        "response_root": "/WorkGroups",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/NextToken",
+          "max_results_param": "MaxResults",
+          "max_results": 50
+        }
       },
       "field_mappings": {
         "Name": { "source": "/Name", "default": "-" },

--- a/src/resources/autoscaling.json
+++ b/src/resources/autoscaling.json
@@ -24,7 +24,13 @@
       "api_config": {
         "protocol": "query",
         "action": "DescribeAutoScalingGroups",
-        "response_root": "/DescribeAutoScalingGroupsResponse/DescribeAutoScalingGroupsResult/AutoScalingGroups/member"
+        "response_root": "/DescribeAutoScalingGroupsResponse/DescribeAutoScalingGroupsResult/AutoScalingGroups/member",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/DescribeAutoScalingGroupsResponse/DescribeAutoScalingGroupsResult/NextToken",
+          "max_results_param": "MaxRecords",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "AutoScalingGroupName": { "source": "/AutoScalingGroupName", "default": "-" },

--- a/src/resources/cloudformation.json
+++ b/src/resources/cloudformation.json
@@ -44,7 +44,11 @@
       "api_config": {
         "protocol": "query",
         "action": "DescribeStacks",
-        "response_root": "/DescribeStacksResponse/DescribeStacksResult/Stacks/member"
+        "response_root": "/DescribeStacksResponse/DescribeStacksResult/Stacks/member",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/DescribeStacksResponse/DescribeStacksResult/NextToken"
+        }
       },
       "field_mappings": {
         "StackName": { "source": "/StackName", "default": "-" },
@@ -87,6 +91,10 @@
         "protocol": "query",
         "action": "DescribeStackEvents",
         "response_root": "/DescribeStackEventsResponse/DescribeStackEventsResult/StackEvents/member",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/DescribeStackEventsResponse/DescribeStackEventsResult/NextToken"
+        },
         "param_mapping": {
           "stack_name": "StackName"
         }
@@ -156,6 +164,10 @@
         "protocol": "query",
         "action": "ListStackResources",
         "response_root": "/ListStackResourcesResponse/ListStackResourcesResult/StackResourceSummaries/member",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/ListStackResourcesResponse/ListStackResourcesResult/NextToken"
+        },
         "param_mapping": {
           "stack_name": "StackName"
         }

--- a/src/resources/cloudfront.json
+++ b/src/resources/cloudfront.json
@@ -21,7 +21,13 @@
         "protocol": "rest-xml",
         "method": "GET",
         "path": "/2020-05-31/distribution",
-        "response_root": "/DistributionList/Items/DistributionSummary"
+        "response_root": "/DistributionList/Items/DistributionSummary",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/DistributionList/NextMarker",
+          "max_results_param": "MaxItems",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "Id": { "source": "/Id", "default": "-" },

--- a/src/resources/cloudwatch.json
+++ b/src/resources/cloudwatch.json
@@ -29,7 +29,13 @@
         "protocol": "json",
         "service_name": "logs",
         "action": "DescribeLogGroups",
-        "response_root": "/logGroups"
+        "response_root": "/logGroups",
+        "pagination": {
+          "input_token": "nextToken",
+          "output_token": "/nextToken",
+          "max_results_param": "limit",
+          "max_results": 50
+        }
       },
       "field_mappings": {
         "logGroupName": { "source": "/logGroupName", "default": "-" },

--- a/src/resources/codepipeline.json
+++ b/src/resources/codepipeline.json
@@ -20,7 +20,13 @@
       "api_config": {
         "protocol": "json",
         "action": "ListPipelines",
-        "response_root": "/pipelines"
+        "response_root": "/pipelines",
+        "pagination": {
+          "input_token": "nextToken",
+          "output_token": "/nextToken",
+          "max_results_param": "maxResults",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "name": { "source": "/name", "default": "-" },

--- a/src/resources/cognito.json
+++ b/src/resources/cognito.json
@@ -22,6 +22,10 @@
         "service_name": "cognito-idp",
         "action": "ListUserPools",
         "response_root": "/UserPools",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/NextToken"
+        },
         "static_params": {
           "MaxResults": 60
         }

--- a/src/resources/dynamodb.json
+++ b/src/resources/dynamodb.json
@@ -20,7 +20,13 @@
       "api_config": {
         "protocol": "json",
         "action": "ListTables",
-        "response_root": "/TableNames"
+        "response_root": "/TableNames",
+        "pagination": {
+          "input_token": "ExclusiveStartTableName",
+          "output_token": "/LastEvaluatedTableName",
+          "max_results_param": "Limit",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "TableName": { "source": "" }

--- a/src/resources/ec2.json
+++ b/src/resources/ec2.json
@@ -101,7 +101,13 @@
       "api_config": {
         "protocol": "query",
         "action": "DescribeVolumes",
-        "response_root": "/DescribeVolumesResponse/volumeSet/item"
+        "response_root": "/DescribeVolumesResponse/volumeSet/item",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/DescribeVolumesResponse/nextToken",
+          "max_results_param": "MaxResults",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "VolumeId": { "source": "/volumeId", "default": "-" },
@@ -160,6 +166,12 @@
         "protocol": "query",
         "action": "DescribeSnapshots",
         "response_root": "/DescribeSnapshotsResponse/snapshotSet/item",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/DescribeSnapshotsResponse/nextToken",
+          "max_results_param": "MaxResults",
+          "max_results": 100
+        },
         "static_params": {
           "Owner.1": "self"
         }

--- a/src/resources/ecr.json
+++ b/src/resources/ecr.json
@@ -19,7 +19,13 @@
       "api_config": {
         "protocol": "json",
         "action": "DescribeRepositories",
-        "response_root": "/repositories"
+        "response_root": "/repositories",
+        "pagination": {
+          "input_token": "nextToken",
+          "output_token": "/nextToken",
+          "max_results_param": "maxResults",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "repositoryName": { "source": "/repositoryName", "default": "-" },

--- a/src/resources/elasticache.json
+++ b/src/resources/elasticache.json
@@ -21,7 +21,13 @@
       "api_config": {
         "protocol": "query",
         "action": "DescribeCacheClusters",
-        "response_root": "/DescribeCacheClustersResponse/DescribeCacheClustersResult/CacheClusters/CacheCluster"
+        "response_root": "/DescribeCacheClustersResponse/DescribeCacheClustersResult/CacheClusters/CacheCluster",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/DescribeCacheClustersResponse/DescribeCacheClustersResult/Marker",
+          "max_results_param": "MaxRecords",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "CacheClusterId": { "source": "/CacheClusterId", "default": "-" },

--- a/src/resources/elbv2.json
+++ b/src/resources/elbv2.json
@@ -27,7 +27,13 @@
       "api_config": {
         "protocol": "query",
         "action": "DescribeLoadBalancers",
-        "response_root": "/DescribeLoadBalancersResponse/DescribeLoadBalancersResult/LoadBalancers/member"
+        "response_root": "/DescribeLoadBalancersResponse/DescribeLoadBalancersResult/LoadBalancers/member",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/DescribeLoadBalancersResponse/DescribeLoadBalancersResult/NextMarker",
+          "max_results_param": "PageSize",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "LoadBalancerArn": { "source": "/LoadBalancerArn", "default": "-" },
@@ -81,6 +87,12 @@
         "protocol": "query",
         "action": "DescribeListeners",
         "response_root": "/DescribeListenersResponse/DescribeListenersResult/Listeners/member",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/DescribeListenersResponse/DescribeListenersResult/NextMarker",
+          "max_results_param": "PageSize",
+          "max_results": 100
+        },
         "param_mapping": {
           "load_balancer_arn": "LoadBalancerArn"
         }
@@ -127,6 +139,12 @@
         "protocol": "query",
         "action": "DescribeRules",
         "response_root": "/DescribeRulesResponse/DescribeRulesResult/Rules/member",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/DescribeRulesResponse/DescribeRulesResult/NextMarker",
+          "max_results_param": "PageSize",
+          "max_results": 100
+        },
         "param_mapping": {
           "listener_arn": "ListenerArn"
         }
@@ -175,6 +193,12 @@
         "protocol": "query",
         "action": "DescribeTargetGroups",
         "response_root": "/DescribeTargetGroupsResponse/DescribeTargetGroupsResult/TargetGroups/member",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/DescribeTargetGroupsResponse/DescribeTargetGroupsResult/NextMarker",
+          "max_results_param": "PageSize",
+          "max_results": 100
+        },
         "param_mapping": {
           "load_balancer_arn": "LoadBalancerArn"
         }

--- a/src/resources/eventbridge.json
+++ b/src/resources/eventbridge.json
@@ -21,7 +21,13 @@
         "protocol": "json",
         "service_name": "events",
         "action": "ListRules",
-        "response_root": "/Rules"
+        "response_root": "/Rules",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/NextToken",
+          "max_results_param": "Limit",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "Name": { "source": "/Name", "default": "-" },
@@ -50,7 +56,13 @@
         "protocol": "json",
         "service_name": "events",
         "action": "ListEventBuses",
-        "response_root": "/EventBuses"
+        "response_root": "/EventBuses",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/NextToken",
+          "max_results_param": "Limit",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "Name": { "source": "/Name", "default": "-" },

--- a/src/resources/iam.json
+++ b/src/resources/iam.json
@@ -24,7 +24,13 @@
       "api_config": {
         "protocol": "query",
         "action": "ListUsers",
-        "response_root": "/ListUsersResponse/ListUsersResult/Users/member"
+        "response_root": "/ListUsersResponse/ListUsersResult/Users/member",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/ListUsersResponse/ListUsersResult/Marker",
+          "max_results_param": "MaxItems",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "UserId": { "source": "/UserId", "default": "-" },
@@ -62,6 +68,12 @@
         "response_root": "/ListAttachedUserPoliciesResponse/ListAttachedUserPoliciesResult/AttachedPolicies/member",
         "param_mapping": {
           "user_name": "UserName"
+        },
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/ListAttachedUserPoliciesResponse/ListAttachedUserPoliciesResult/Marker",
+          "max_results_param": "MaxItems",
+          "max_results": 100
         }
       },
       "field_mappings": {
@@ -92,6 +104,12 @@
         "response_root": "/ListGroupsForUserResponse/ListGroupsForUserResult/Groups/member",
         "param_mapping": {
           "user_name": "UserName"
+        },
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/ListGroupsForUserResponse/ListGroupsForUserResult/Marker",
+          "max_results_param": "MaxItems",
+          "max_results": 100
         }
       },
       "field_mappings": {
@@ -123,6 +141,12 @@
         "response_root": "/ListAccessKeysResponse/ListAccessKeysResult/AccessKeyMetadata/member",
         "param_mapping": {
           "user_name": "UserName"
+        },
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/ListAccessKeysResponse/ListAccessKeysResult/Marker",
+          "max_results_param": "MaxItems",
+          "max_results": 100
         }
       },
       "field_mappings": {
@@ -153,7 +177,13 @@
       "api_config": {
         "protocol": "query",
         "action": "ListRoles",
-        "response_root": "/ListRolesResponse/ListRolesResult/Roles/member"
+        "response_root": "/ListRolesResponse/ListRolesResult/Roles/member",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/ListRolesResponse/ListRolesResult/Marker",
+          "max_results_param": "MaxItems",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "RoleId": { "source": "/RoleId", "default": "-" },
@@ -192,6 +222,12 @@
         "response_root": "/ListAttachedRolePoliciesResponse/ListAttachedRolePoliciesResult/AttachedPolicies/member",
         "param_mapping": {
           "role_name": "RoleName"
+        },
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/ListAttachedRolePoliciesResponse/ListAttachedRolePoliciesResult/Marker",
+          "max_results_param": "MaxItems",
+          "max_results": 100
         }
       },
       "field_mappings": {
@@ -225,6 +261,12 @@
         "response_root": "/ListPoliciesResponse/ListPoliciesResult/Policies/member",
         "static_params": {
           "Scope": "Local"
+        },
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/ListPoliciesResponse/ListPoliciesResult/Marker",
+          "max_results_param": "MaxItems",
+          "max_results": 100
         }
       },
       "field_mappings": {
@@ -259,7 +301,13 @@
       "api_config": {
         "protocol": "query",
         "action": "ListGroups",
-        "response_root": "/ListGroupsResponse/ListGroupsResult/Groups/member"
+        "response_root": "/ListGroupsResponse/ListGroupsResult/Groups/member",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/ListGroupsResponse/ListGroupsResult/Marker",
+          "max_results_param": "MaxItems",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "GroupId": { "source": "/GroupId", "default": "-" },
@@ -292,6 +340,12 @@
         "response_root": "/GetGroupResponse/GetGroupResult/Users/member",
         "param_mapping": {
           "group_name": "GroupName"
+        },
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/GetGroupResponse/GetGroupResult/Marker",
+          "max_results_param": "MaxItems",
+          "max_results": 100
         }
       },
       "field_mappings": {

--- a/src/resources/rds.json
+++ b/src/resources/rds.json
@@ -28,7 +28,13 @@
       "api_config": {
         "protocol": "query",
         "action": "DescribeDBInstances",
-        "response_root": "/DescribeDBInstancesResponse/DescribeDBInstancesResult/DBInstances/DBInstance"
+        "response_root": "/DescribeDBInstancesResponse/DescribeDBInstancesResult/DBInstances/DBInstance",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/DescribeDBInstancesResponse/DescribeDBInstancesResult/Marker",
+          "max_results_param": "MaxRecords",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "DBInstanceIdentifier": { "source": "/DBInstanceIdentifier", "default": "-" },
@@ -99,6 +105,12 @@
         "protocol": "query",
         "action": "DescribeDBSnapshots",
         "response_root": "/DescribeDBSnapshotsResponse/DescribeDBSnapshotsResult/DBSnapshots/DBSnapshot",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/DescribeDBSnapshotsResponse/DescribeDBSnapshotsResult/Marker",
+          "max_results_param": "MaxRecords",
+          "max_results": 100
+        },
         "param_mapping": {
           "db_instance_identifier": "DBInstanceIdentifier"
         }

--- a/src/resources/redshift.json
+++ b/src/resources/redshift.json
@@ -29,7 +29,13 @@
       "api_config": {
         "protocol": "query",
         "action": "DescribeClusters",
-        "response_root": "/DescribeClustersResponse/DescribeClustersResult/Clusters/Cluster"
+        "response_root": "/DescribeClustersResponse/DescribeClustersResult/Clusters/Cluster",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/DescribeClustersResponse/DescribeClustersResult/Marker",
+          "max_results_param": "MaxRecords",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "ClusterIdentifier": { "source": "/ClusterIdentifier", "default": "-" },
@@ -101,6 +107,12 @@
         "protocol": "query",
         "action": "DescribeClusterSnapshots",
         "response_root": "/DescribeClusterSnapshotsResponse/DescribeClusterSnapshotsResult/Snapshots/Snapshot",
+        "pagination": {
+          "input_token": "Marker",
+          "output_token": "/DescribeClusterSnapshotsResponse/DescribeClusterSnapshotsResult/Marker",
+          "max_results_param": "MaxRecords",
+          "max_results": 100
+        },
         "param_mapping": {
           "cluster_identifier": "ClusterIdentifier"
         }

--- a/src/resources/route53.json
+++ b/src/resources/route53.json
@@ -23,7 +23,13 @@
         "protocol": "rest-xml",
         "method": "GET",
         "path": "/2013-04-01/hostedzone",
-        "response_root": "/ListHostedZonesResponse/HostedZones/HostedZone"
+        "response_root": "/ListHostedZonesResponse/HostedZones/HostedZone",
+        "pagination": {
+          "input_token": "marker",
+          "output_token": "/ListHostedZonesResponse/NextMarker",
+          "max_results_param": "maxitems",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "Id": { "source": "/Id", "default": "-" },

--- a/src/resources/sns.json
+++ b/src/resources/sns.json
@@ -19,7 +19,11 @@
       "api_config": {
         "protocol": "query",
         "action": "ListTopics",
-        "response_root": "/ListTopicsResponse/ListTopicsResult/Topics/member"
+        "response_root": "/ListTopicsResponse/ListTopicsResult/Topics/member",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/ListTopicsResponse/ListTopicsResult/NextToken"
+        }
       },
       "field_mappings": {
         "TopicArn": { "source": "/TopicArn", "default": "-" }

--- a/src/resources/sqs.json
+++ b/src/resources/sqs.json
@@ -20,7 +20,13 @@
       "api_config": {
         "protocol": "query",
         "action": "ListQueues",
-        "response_root": "/ListQueuesResponse/ListQueuesResult/QueueUrl"
+        "response_root": "/ListQueuesResponse/ListQueuesResult/QueueUrl",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/ListQueuesResponse/ListQueuesResult/NextToken",
+          "max_results_param": "MaxResults",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "QueueUrl": { "source": "", "default": "-" }

--- a/src/resources/vpc.json
+++ b/src/resources/vpc.json
@@ -25,7 +25,13 @@
       "api_config": {
         "protocol": "query",
         "action": "DescribeVpcs",
-        "response_root": "/DescribeVpcsResponse/vpcSet/item"
+        "response_root": "/DescribeVpcsResponse/vpcSet/item",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/DescribeVpcsResponse/nextToken",
+          "max_results_param": "MaxResults",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "VpcId": { "source": "/vpcId", "default": "-" },
@@ -62,7 +68,13 @@
       "api_config": {
         "protocol": "query",
         "action": "DescribeSubnets",
-        "response_root": "/DescribeSubnetsResponse/subnetSet/item"
+        "response_root": "/DescribeSubnetsResponse/subnetSet/item",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/DescribeSubnetsResponse/nextToken",
+          "max_results_param": "MaxResults",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "SubnetId": { "source": "/subnetId", "default": "-" },
@@ -97,7 +109,13 @@
       "api_config": {
         "protocol": "query",
         "action": "DescribeSecurityGroups",
-        "response_root": "/DescribeSecurityGroupsResponse/securityGroupInfo/item"
+        "response_root": "/DescribeSecurityGroupsResponse/securityGroupInfo/item",
+        "pagination": {
+          "input_token": "NextToken",
+          "output_token": "/DescribeSecurityGroupsResponse/nextToken",
+          "max_results_param": "MaxResults",
+          "max_results": 100
+        }
       },
       "field_mappings": {
         "GroupId": { "source": "/groupId", "default": "-" },


### PR DESCRIPTION
## Problem

`]` and `[` did nothing on most resource views, and lists were silently capped at whatever each AWS API returns by default. On IAM Roles this shows as exactly 100 rows with no way to see the rest (the account I hit has 197).

Two separate causes:

1. **Missing pagination config.** Only 12 of 60 resources declared `api_config.pagination`. Without an `output_token` the handlers return `next_token: None`, so `pagination.has_more` stays `false` and the `]` handler in `src/event.rs` is a no-op. No page indicator is drawn either, so the cap is invisible.

2. **The JSON protocol handler never sent the token.** `json.rs` skipped all params starting with `_`, including `_page_token`, and had no pagination branch. The 6 JSON-protocol resources that already declared pagination detected `has_more` from the response but re-requested page 1 on every `]`, showing the same rows again. `rest_xml.rs` sent the marker but ignored `max_results_param`.

## Changes

- `json.rs`: send `input_token` and `max_results_param` in the request body, applied after static/dynamic params so a page token always wins.
- `rest_xml.rs`: send `max_results_param` as a query param alongside the existing marker.
- 41 resources gained a `pagination` block, taking coverage from 12/60 to 53/60.

Token names follow each API rather than one blanket pattern: `Marker` for IAM/RDS/Redshift/ElastiCache, `NextMarker` in ELBv2 responses, lowercase `nextToken` for EC2/VPC, `ExclusiveStartTableName`/`LastEvaluatedTableName` for DynamoDB. Page sizes respect documented caps (Athena 50, CloudWatch Logs `limit` 50, ELBv2 `PageSize`, `MaxRecords` for RDS/Redshift/ElastiCache).

## Deliberately not paginated

| Resource | Reason |
| --- | --- |
| `cloudtrail-trails`, `elbv2-targets` | `DescribeTrails` / `DescribeTargetHealth` are not paginated |
| `cloudformation-outputs` | Reads a single stack, so a token would page stacks rather than outputs |
| `route53-records` | Needs two continuation tokens (`NextRecordName` + `NextRecordType`); the config supports one |
| `s3-buckets` | `max-buckets` would cap the list at 100, and an endpoint that ignores `continuation-token` would hide buckets visible today |

## Testing

Verified against a real AWS account (197 IAM roles):

- `:iam-roles` → `ListRoles&MaxItems=100`, response `IsTruncated=true` plus a `Marker`.
- `]` → next request carries `Marker=…`, returns the remaining 97 with `IsTruncated=false`, so `]` correctly stops.
- `[` → returns to page 1.
- Handler fixes confirmed on the wire: CloudWatch log groups now send body `{"limit":50}` (previously nothing), Route53 sends `?maxitems=100`, CloudFront `?MaxItems=100`, API Gateway `?limit=100`.
- Smoke-tested 27 resource views, 28 requests, no 4xx from any new config. Two unrelated pre-existing failures showed up: `dynamodb-tables` returns a 404 HTML page (reproduces identically on master) and `codepipeline-pipelines` returned `AccessDeniedException` for my role.
- `cargo test` 115/115 with `--test-threads=1`, `cargo fmt --check` clean, no new clippy warnings.

Known limit: token extraction is only exercised end-to-end for IAM, since the test account has fewer than 100 items in the other resources, so those APIs returned no token to extract. Params are validated by the API in every case; output paths are from the API docs.