### PR TITLE
fix: allow "/" to be typed in the resource filter

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -366,14 +366,10 @@ async fn handle_filter_input(app: &mut App, key: KeyEvent) -> Result<bool> {
             app.filters_autocomplete_shown = app.should_show_filters_autocomplete();
             app.apply_filter();
         }
-        KeyCode::Char('/') => {
-            // Pressing '/' again clears and restarts the filter (including AWS filters)
-            if app.start_new_filter() {
-                // AWS filters were cleared, need to refresh to remove server-side filter
-                app.refresh_current().await?;
-            }
-            app.apply_filter();
-        }
+        // '/' gets no special treatment here. Entering the filter already goes through
+        // `start_new_filter`, so there is nothing left to reset, and treating it as an
+        // ordinary character is what makes path-style names such as `my/secret` or
+        // `/prod/db` searchable.
         KeyCode::Char(c) => {
             app.filter_text.push(c);
             // Update autocomplete state

--- a/src/event.rs
+++ b/src/event.rs
@@ -725,11 +725,7 @@ async fn handle_sso_login_mode(app: &mut App, key: KeyEvent) -> Result<bool> {
             }
         }
 
-        SsoLoginState::WaitingForAuth {
-            profile,
-            interval: _,
-            ..
-        } => {
+        SsoLoginState::WaitingForAuth { profile, .. } => {
             match key.code {
                 KeyCode::Esc => {
                     app.sso_state = None;


### PR DESCRIPTION
## Related Issue

Closes #157
Closes #150

## Description

Lets `/` be typed inside the resource filter instead of clearing it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have linked this PR to an existing issue
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [ ] I have added/updated relevant documentation (if applicable)
- [x] My changes don't introduce new warnings

## Additional Notes

No unit test — `handle_filter_input` needs a live `App`, which felt like a lot of setup for a match arm being deleted. Checked in the TUI instead: typing `/prod/db` on master leaves `db` in the filter bar, on this branch it leaves `/prod/db`.

## Demo

Reproduced with [`laws`](https://github.com/huseyinbabal/laws) (local AWS emulator) instead of a real account:
`laws --port 4566`, then `taws --endpoint-url http://localhost:4566`, with SSM parameters
`/prod/db/host`, `/prod/db/password`, `/prod/api/key`, `/staging/db/password`, `plain-param`.

Steps in both builds: `:ssm-parameters` → `/` → type `prod/db`

**master — `/` restarts the filter mid-typing, only `db` survives and `/staging/db/password` leaks into the results (3/5):**

![master bug](https://raw.githubusercontent.com/Rfetha/taws/pr-182-media/pr-182/01-master-bug.png)

**this PR — the full `/prod/db` stays in the filter, results narrow to the intended two (2/5):**

![fixed](https://raw.githubusercontent.com/Rfetha/taws/pr-182-media/pr-182/02-fix-resolved.png)

### Regression check

`/` in **normal** mode still clears an active server-side filter — that path in `handle_normal_mode` is untouched.
Verified against `laws` with `ec2-instances`: apply `Filters: tag:Name=alpha`, then press `/`; the
`[Filters: tag:Name=alpha]` badge disappears and the list refreshes — identical output on `master` and on this branch.
`Esc` still clears the filter. `filter_active` is only ever set in `start_new_filter()`, which nulls `aws_filters`
first, so the `refresh_current()` call in the deleted arm was unreachable in practice.

`cargo test`: 114 passed, 1 failed — `aws::credentials::tests::test_credential_process_success`, which fails on
`master` too (pre-existing, Windows-only). `cargo clippy --all-targets`: clean.
