### PR TITLE
fix: keep taws alive when Ctrl-C is pressed in an SSM session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,6 +2819,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "fuzzy-matcher",
+ "libc",
  "open",
  "quick-xml",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,10 @@ fuzzy-matcher = "0.3.7"
 async-trait = "0.1.89"
 arboard = "3.6"
 
+# Ctrl-C must not kill taws while an SSM session owns the terminal (no stdlib API for this)
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 dirs = "6.0"
 tempfile = "3.24.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1446,6 +1446,30 @@ where
     }
 }
 
+/// Ignores SIGINT for as long as the guard lives, restoring the previous handler on drop.
+///
+/// While an SSM session runs the TUI is suspended, so the terminal is back in canonical
+/// mode and Ctrl-C is delivered as SIGINT to the entire foreground process group, taws
+/// included. Cancelling a remote command would therefore also kill taws.
+#[cfg(unix)]
+struct IgnoreSigint(libc::sighandler_t);
+
+#[cfg(unix)]
+impl IgnoreSigint {
+    fn install() -> Self {
+        // SAFETY: `signal` only swaps this process's own SIGINT disposition.
+        Self(unsafe { libc::signal(libc::SIGINT, libc::SIG_IGN) })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for IgnoreSigint {
+    fn drop(&mut self) {
+        // SAFETY: restores exactly the handler captured by `install`.
+        unsafe { libc::signal(libc::SIGINT, self.0) };
+    }
+}
+
 /// Execute SSM connect by suspending TUI and running aws ssm start-session
 fn execute_ssm_connect<B: Backend>(
     terminal: &mut Terminal<B>,
@@ -1472,18 +1496,38 @@ where
     std::io::stdout().flush()?;
 
     // Run aws ssm start-session
-    let status = std::process::Command::new("aws")
-        .args([
-            "ssm",
-            "start-session",
-            "--target",
-            &request.instance_id,
-            "--region",
-            &request.region,
-            "--profile",
-            &request.profile,
-        ])
-        .status();
+    let mut command = std::process::Command::new("aws");
+    command.args([
+        "ssm",
+        "start-session",
+        "--target",
+        &request.instance_id,
+        "--region",
+        &request.region,
+        "--profile",
+        &request.profile,
+    ]);
+
+    // The child keeps the default handler so Ctrl-C can still abort a session that is
+    // stuck connecting. Once the session is up, the AWS CLI and session-manager-plugin
+    // ignore SIGINT themselves and hand Ctrl-C to the remote shell as input.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: `signal` is async-signal-safe, so it is valid between fork and exec.
+        unsafe {
+            command.pre_exec(|| {
+                libc::signal(libc::SIGINT, libc::SIG_DFL);
+                Ok(())
+            });
+        }
+    }
+
+    let status = {
+        #[cfg(unix)]
+        let _ignore_sigint = IgnoreSigint::install();
+        command.status()
+    };
 
     match status {
         Ok(exit_status) => {


### PR DESCRIPTION
## Related Issue

Closes #132
Closes #156

## Description

Connecting to an instance suspends the TUI, so the terminal goes back to canonical mode
and Ctrl-C is delivered as SIGINT to the whole foreground process group. The AWS CLI and
session-manager-plugin ignore SIGINT themselves, so taws was the only process that died:
cancelling a `tail -f` on the remote host tore down the TUI and the session with it.

taws now ignores SIGINT for as long as the session runs and restores the previous handler
afterwards, the way `system(3)` does. The child resets the handler to its default before
exec, so Ctrl-C can still abort a session that is stuck connecting; once the session is up
the plugin forwards Ctrl-C to the remote shell as input.

Changes:
- `IgnoreSigint` RAII guard in `src/main.rs` — installs `SIG_IGN` for the lifetime of the
  session and restores the captured handler on drop.
- `pre_exec` hook resets SIGINT to `SIG_DFL` in the child, since an ignored disposition is
  otherwise inherited across fork/exec.
- `libc` added as a `cfg(unix)`-only dependency (no stdlib API covers this).

This covers Unix only. Windows consoles would need `SetConsoleCtrlHandler` and a
`windows-sys` dependency; both reports are from Linux, so that is left out.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have linked this PR to an existing issue
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] I have added/updated relevant documentation (if applicable)
- [x] My changes don't introduce new warnings

## Screenshots (if applicable)

N/A — no UI change.

## Additional Notes

- Signal behaviour is not unit-testable, so no test was added. Verified manually: Ctrl-C
  during a remote `tail -f` cancels the remote command and leaves taws running, and Ctrl-C
  while the session is still connecting still aborts it.
- Rebased on current `master`; `cargo fmt -- --check`, `cargo clippy -- -D warnings` and
  `cargo test` all pass locally.
